### PR TITLE
RDB Shredder: overwrite output datasets (closes #41)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val loader = project.in(file("."))
 lazy val shredder = project.in(file("shredder"))
   .settings(
     name        := "snowplow-rdb-shredder",
-    version     := "0.12.0",
+    version     := "0.13.0",
     description := "Spark job to shred event and context JSONs from Snowplow enriched events",
     BuildSettings.oneJvmPerTestSetting // ensures that only CrossBatchDeduplicationSpec has a DuplicateStorage
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
 
     // Scala (Shredder)
     val spark           = "2.1.0"
-    val commonEnrich    = "0.25.0"
+    val commonEnrich    = "0.27.0"
 
     // Java (Loader)
     val postgres         = "42.0.0"

--- a/shredder/src/main/scala/com.snowplowanalytics.snowplow.storage/spark/ShredJob.scala
+++ b/shredder/src/main/scala/com.snowplowanalytics.snowplow.storage/spark/ShredJob.scala
@@ -27,7 +27,8 @@ import com.fasterxml.jackson.databind.JsonNode
 // Spark
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.serializer.KryoSerializer
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 // Scalaz
 import scalaz._
@@ -345,7 +346,7 @@ class ShredJob(@transient val spark: SparkSession, args: Array[String]) extends 
     // Handling of malformed rows
     val bad = common
       .flatMap { case (line, shredded) => projectBads(line, shredded) }
-      .map { case (line, errors) => new BadRow(line, errors).toCompactJson }
+      .map { case (line, errors) => Row(BadRow(line, errors).toCompactJson) }
 
     // Handling of properly-formed rows, only one event from an event id and event fingerprint
     // combination is kept
@@ -393,10 +394,13 @@ class ShredJob(@transient val spark: SparkSession, args: Array[String]) extends 
     // Write errors unioned with errors occurred during cross-batch deduplication
     val badDupes = bad ++ dupeFailed
       .flatMap { case (s, dupe) => dupe match {
-        case Failure(m) => Some(new BadRow(s.originalLine, m).toCompactJson)
+        case Failure(m) => Some(Row(BadRow(s.originalLine, m).toCompactJson))
         case _ => None
-      }}
-    badDupes.saveAsTextFile(shredConfig.badFolder)
+      } }
+    spark.createDataFrame(badDupes, StructType(StructField("_", StringType, true) :: Nil))
+      .write
+      .mode(SaveMode.Overwrite)
+      .text(shredConfig.badFolder)
 
     // Create duplicate JSON contexts for well-formed events having duplicates
     // This creates not canonical contexts (with schema and data), but shredded hierarchies
@@ -407,8 +411,11 @@ class ShredJob(@transient val spark: SparkSession, args: Array[String]) extends 
 
     // Ready the events for database load
     val events = goodWithSyntheticDupes
-      .map(e => alterEnrichedEvent(e.shredded.originalLine, e.newEventId))
-    events.saveAsTextFile(getAlteredEnrichedOutputPath(shredConfig.outFolder))
+      .map(e => Row(alterEnrichedEvent(e.shredded.originalLine, e.newEventId)))
+    spark.createDataFrame(events, StructType(StructField("_", StringType, true) :: Nil))
+      .write
+      .mode(SaveMode.Overwrite)
+      .text(getAlteredEnrichedOutputPath(shredConfig.outFolder))
 
     // Update the shredded JSONs with the new deduplicated event IDs and stringify
     val jsons = (goodWithSyntheticDupes


### PR DESCRIPTION
- [x] downstream component depending on events (loader)
- [x] downstream component depending on bad rows (es?)