### PR TITLE
Add more tests for transformer-kinesis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,10 @@ lazy val transformerKinesis = project.in(file("modules/transformer-kinesis"))
       Dependencies.specs2,
       Dependencies.specs2ScalaCheck,
       Dependencies.scalaCheck
-    ).map(_.excludeAll(ExclusionRule(organization = "org.slf4j", name = "slf4j-log4j12")))
+    ).map(_
+      .excludeAll(ExclusionRule(organization = "org.slf4j", name = "slf4j-log4j12"))
+      .excludeAll(ExclusionRule(organization = "ch.qos.logback"))
+    )
   )
   .dependsOn(common, aws)
   .enablePlugins(JavaAppPackaging, DockerPlugin, BuildInfoPlugin)

--- a/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/Resources.scala
+++ b/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/Resources.scala
@@ -1,28 +1,19 @@
 package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis
 
-import java.util.UUID
-
-import scala.concurrent.duration._
-
-import cats.data.EitherT
-import cats.implicits._
-
 import cats.effect.concurrent.Ref
-import cats.effect.{Blocker, Clock, Resource, Timer, Concurrent, Sync}
-
-import fs2.concurrent.SignallingRef
-
-import io.circe.Json
-
-import org.typelevel.log4cats.slf4j.Slf4jLogger
-
+import cats.effect.{Blocker, Clock, Concurrent, Resource, Sync, Timer}
+import cats.implicits._
+import com.snowplowanalytics.aws.AWSQueue
 import com.snowplowanalytics.iglu.client.Client
-import com.snowplowanalytics.iglu.client.resolver.{InitSchemaCache, InitListCache}
-
+import com.snowplowanalytics.iglu.client.resolver.{InitListCache, InitSchemaCache, Resolver}
 import com.snowplowanalytics.snowplow.rdbloader.common.transformation.EventUtils
+import fs2.concurrent.SignallingRef
+import io.circe.Json
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import com.snowplowanalytics.snowplow.rdbloader.common.config.TransformerConfig.QueueConfig
 
-import com.snowplowanalytics.aws.AWSQueue
+import java.util.UUID
+import scala.concurrent.duration.DurationInt
 
 case class Resources[F[_]](iglu: Client[F, Json],
                            atomicLengths: Map[String, Int],
@@ -35,45 +26,75 @@ case class Resources[F[_]](iglu: Client[F, Json],
 
 object Resources {
 
-  private implicit def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
+  implicit private def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
 
-  def mk[F[_]: Concurrent: Clock: InitSchemaCache: InitListCache: Timer](igluConfig: Json, queueConfig: QueueConfig): Resource[F, Resources[F]] = {
-    val init = for {
-      igluClient <- Client.parseDefault[F](igluConfig)
-        .leftMap(e => new RuntimeException(s"Error while parsing Iglu config: ${e.getMessage()}"))
-      atomicLengths <- EitherT(EventUtils.getAtomicLengths(igluClient.resolver))
-    } yield (igluClient, atomicLengths)
-    val client = init.value.flatMap {
-      case Right(init) => Sync[F].pure(init)
-      case Left(error) => Sync[F].raiseError[(Client[F, Json], Map[String, Int])](error)
-    }
-
-    for {
-      (client, lengths) <- Resource.eval(client)
-      blocker <- Blocker[F]
-      state <- Resource.make(State.init[F]) { global =>
-        global.get.flatMap { stack =>
-          if (stack.isEmpty)
-            logger.warn(s"Final window state is empty")
-          else
-            logger.info(s"Final window state:\n${stack.mkString("\n")}")
-        }
-      }
-      awsQueue <- queueConfig match {
-        case QueueConfig.SQS(queueName, region) => AWSQueue.build(AWSQueue.QueueType.SQS, queueName, region.name)
-        case QueueConfig.SNS(topicArn, region) => AWSQueue.build(AWSQueue.QueueType.SNS, topicArn, region.name)
-      }
-      sinks <- Resource.eval(Ref.of(0L))
-      instanceId <- Resource
-        .eval(Sync[F].delay(UUID.randomUUID()))
-        .evalTap(id => logger[F].info(s"Instantiated $id shredder instance"))
-      halt <- Resource.make(SignallingRef(false)) { s =>
-        logger[F].warn("Halting the source, sleeping for 5 seconds...") *>
-          s.set(true) *>
-          Timer[F].sleep(5.seconds) *>
-          logger[F].warn(s"Shutting down $instanceId instance")
-      }
-    } yield Resources(client, lengths, awsQueue, instanceId.toString, blocker, halt, state, sinks)
+  def mk[F[_]: Concurrent: Clock: InitSchemaCache: InitListCache: Timer](igluConfig: Json,
+                                                                         queueConfig: QueueConfig): Resource[F, Resources[F]] = {
+    mkQueueFromConfig(queueConfig).flatMap(mk(igluConfig, _))
   }
-}
 
+  def mk[F[_]: Concurrent: Clock: InitSchemaCache: InitListCache: Timer](igluConfig: Json,
+                                                                         awsQueue: AWSQueue[F]): Resource[F, Resources[F]] = {
+    for {
+      client        <- mkClient(igluConfig)
+      atomicLengths <- mkAtomicFieldLengthLimit(client.resolver)
+      blocker       <- Blocker[F]
+      initialState  <- mkInitialState
+      sinks         <- Resource.eval(Ref.of(0L))
+      instanceId    <- mkTransformerInstanceId
+      halt          <- mkHaltingSignal(instanceId)
+    } yield Resources(client, atomicLengths, awsQueue, instanceId.toString, blocker, halt, initialState, sinks)
+  }
+
+  private def mkClient[F[_]: Sync: InitSchemaCache: InitListCache](igluConfig: Json): Resource[F, Client[F, Json]] = Resource.eval {
+    Client
+      .parseDefault[F](igluConfig)
+      .leftMap(e => new RuntimeException(s"Error while parsing Iglu config: ${e.getMessage()}"))
+      .value
+      .flatMap {
+        case Right(init) => Sync[F].pure(init)
+        case Left(error) => Sync[F].raiseError[Client[F, Json]](error)
+      }
+  }
+
+  private def mkAtomicFieldLengthLimit[F[_]: Sync: Clock](igluResolver: Resolver[F]): Resource[F, Map[String, Int]] = Resource.eval {
+    EventUtils.getAtomicLengths(igluResolver).flatMap {
+      case Right(valid) => Sync[F].pure(valid)
+      case Left(error)  => Sync[F].raiseError[Map[String, Int]](error)
+    }
+  }
+
+  private def mkInitialState[F[_]: Sync] = {
+    Resource.make(State.init[F]) { state =>
+      state.get.flatMap { stack =>
+        if (stack.isEmpty)
+          logger.warn(s"Final window state is empty")
+        else
+          logger.info(s"Final window state:\n${stack.mkString("\n")}")
+      }
+    }
+  }
+
+  private def mkTransformerInstanceId[F[_]: Sync] = {
+    Resource
+      .eval(Sync[F].delay(UUID.randomUUID()))
+      .evalTap(id => logger.info(s"Instantiated $id shredder instance"))
+  }
+
+  private def mkHaltingSignal[F[_]: Concurrent: Timer](instanceId: UUID) = {
+    Resource.make(SignallingRef(false)) { s =>
+      logger.warn("Halting the source, sleeping for 5 seconds...") *>
+        s.set(true) *>
+        Timer[F].sleep(5.seconds) *>
+        logger.warn(s"Shutting down $instanceId instance")
+    }
+  }
+
+  private def mkQueueFromConfig[F[_]: Concurrent](queueConfig: QueueConfig): Resource[F, AWSQueue[F]] = {
+    queueConfig match {
+      case QueueConfig.SQS(queueName, region) => AWSQueue.build(AWSQueue.QueueType.SQS, queueName, region.name)
+      case QueueConfig.SNS(topicArn, region)  => AWSQueue.build(AWSQueue.QueueType.SNS, topicArn, region.name)
+    }
+  }
+
+}

--- a/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/tsv/completion.json
+++ b/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/tsv/completion.json
@@ -1,0 +1,130 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage.rdbloader/shredding_complete/jsonschema/2-0-0",
+  "data": {
+    "base": "s3://output_path_placeholder/run=1970-01-01-10-30-00/",
+    "typesInfo": {
+      "transformation": "SHREDDED",
+      "types": [
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/consent_withdrawn/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+          "format": "TSV",
+          "snowplowEntity": "SELF_DESCRIBING_EVENT"
+        },
+        {
+          "schemaKey": "iglu:com.mparticle.snowplow/session_context/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.mparticle.snowplow/pushregistration_event/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/desktop_context/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.google.analytics/private/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/ua_parser_context/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:org.w3/PerformanceTiming/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.google.analytics/cookies/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/variation/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/visitor/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.segment/screen/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:org.ietf/http_cookie/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely.optimizelyx/summary/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:org.ietf/http_header/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/state/jsonschema/1-0-0",
+          "format": "TSV",
+          "snowplowEntity": "CONTEXT"
+        }
+      ]
+    },
+    "timestamps": {
+      "jobStarted": "1970-01-01T10:30:00Z",
+      "jobCompleted": "1970-01-01T10:31:00Z",
+      "min": "2021-10-13T20:21:47.595072674Z",
+      "max": "2021-10-15T00:51:57.521746512Z"
+    },
+    "compression": "NONE",
+    "processor": {
+      "artifact": "common",
+      "version": "version_placeholder"
+    },
+    "count": {
+      "good": 0
+    }
+  }
+}

--- a/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/widerow/completion.json
+++ b/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/widerow/completion.json
@@ -1,0 +1,110 @@
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow.storage.rdbloader/shredding_complete/jsonschema/2-0-0",
+  "data": {
+    "base": "s3://output_path_placeholder/run=1970-01-01-10-30-00/",
+    "typesInfo": {
+      "transformation": "WIDEROW",
+      "fileFormat": "JSON",
+      "types": [
+        {
+          "schemaKey": "iglu:org.ietf/http_header/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.segment/screen/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/state/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.google.analytics/private/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:org.w3/PerformanceTiming/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.mparticle.snowplow/pushregistration_event/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/desktop_context/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely.optimizelyx/summary/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/ua_parser_context/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/variation/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+          "snowplowEntity": "SELF_DESCRIBING_EVENT"
+        },
+        {
+          "schemaKey": "iglu:com.mparticle.snowplow/session_context/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.optimizely/visitor/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:org.ietf/http_cookie/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.snowplowanalytics.snowplow/consent_withdrawn/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        },
+        {
+          "schemaKey": "iglu:com.google.analytics/cookies/jsonschema/1-0-0",
+          "snowplowEntity": "CONTEXT"
+        }
+      ]
+    },
+    "timestamps": {
+      "jobStarted": "1970-01-01T10:30:00Z",
+      "jobCompleted": "1970-01-01T10:31:00Z",
+      "min": "2021-10-13T20:21:47.595072674Z",
+      "max": "2021-10-15T00:51:57.521746512Z"
+    },
+    "compression": "NONE",
+    "processor": {
+      "artifact": "common",
+      "version": "version_placeholder"
+    },
+    "count": {
+      "good": 0
+    }
+  }
+}

--- a/modules/transformer-kinesis/src/test/resources/simplelogger.properties
+++ b/modules/transformer-kinesis/src/test/resources/simplelogger.properties
@@ -1,7 +1,3 @@
 org.slf4j.simpleLogger.showThreadName=false
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.showShortLogName=true
-
-org.slf4j.simpleLogger.log.com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generic.Partitioned=warn
-org.slf4j.simpleLogger.log.com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generic.KeyedEnqueue=warn
-org.slf4j.simpleLogger.log.com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generic.ItemEnqueue=warn

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/FileUtils.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/FileUtils.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis
+
+import cats.effect.{Blocker, ContextShift, IO, Resource}
+import com.snowplowanalytics.snowplow.rdbloader.generated.BuildInfo
+import fs2.{Stream, text}
+
+import java.nio.file.Path
+
+object FileUtils {
+
+  def createTempDirectory(blocker: Blocker)(implicit cs: ContextShift[IO]): Resource[IO, Path] = {
+    fs2.io.file.tempDirectoryResource[IO](blocker, Path.of(System.getProperty("java.io.tmpdir")))
+  }
+
+  def directoryStream(blocker: Blocker, dir: Path)(implicit cs: ContextShift[IO]): Stream[IO, String] = {
+    fs2.io.file.directoryStream[IO](blocker, dir).flatMap(fileStream(blocker, _))
+  }
+
+  def readLines(blocker: Blocker, resourcePath: String)(implicit cs: ContextShift[IO]): IO[List[String]] = {
+   resourceFileStream(blocker, resourcePath)
+     .map(_.replace("version_placeholder", BuildInfo.version))
+     .compile
+     .toList
+  }
+
+  def resourceFileStream(blocker: Blocker, resourcePath: String)(implicit cs: ContextShift[IO]): Stream[IO, String] = {
+    fileStream(blocker, Path.of(getClass.getResource(resourcePath).getPath))
+  }
+
+  def fileStream(blocker: Blocker, filePath: Path)(implicit cs: ContextShift[IO]): Stream[IO, String] = {
+    fs2.io.file.readAll[IO](filePath, blocker, 4096)
+      .through(text.utf8Decode)
+      .through(text.lines)
+      .filter(_.nonEmpty)
+  }
+
+}

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/WindowedRecordsSpec.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/WindowedRecordsSpec.scala
@@ -10,13 +10,14 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis
 
 import cats.effect.concurrent.Ref
 import cats.effect.laws.util.TestContext
 import cats.effect.{ContextShift, IO, Timer}
-import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.WindowedRecordsSpec.OutputRecord.{Data, End}
-import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.WindowedRecordsSpec._
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.WindowedRecordsSpec.OutputRecord._
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.WindowedRecordsSpec._
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.Window
 import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generic.Record
 import fs2.Stream
 import org.specs2.mutable.Specification

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/BaseProcessingSpec.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/BaseProcessingSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing
+
+import cats.effect.concurrent.Deferred
+import cats.effect.{Blocker, Clock, ContextShift, IO, Timer}
+import cats.implicits.toTraverseOps
+import com.snowplowanalytics.snowplow.rdbloader.generated.BuildInfo
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.FileUtils
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.FileUtils.{createTempDirectory, directoryStream}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.Processing.Windowed
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing.BaseProcessingSpec.{ConfigProvider, CreatedDirectories, OutputRows, ProcessingOutput, TestResources, TransformerConfig}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sources.Parsed
+import fs2.Stream
+import org.specs2.mutable.Specification
+
+import java.nio.file.Path
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+trait BaseProcessingSpec extends Specification {
+
+  implicit val CS: ContextShift[IO] = IO.contextShift(concurrent.ExecutionContext.global)
+  implicit val T: Timer[IO]         = IO.timer(concurrent.ExecutionContext.global)
+
+  //returns always 1970-01-01-10:31
+  implicit val clock: Clock[IO] = new Clock[IO] {
+    override def realTime(unit: TimeUnit): IO[Long] = IO(unit.convert(37860L, TimeUnit.SECONDS)) 
+    override def monotonic(unit: TimeUnit): IO[Long] = IO(unit.convert(37860L, TimeUnit.SECONDS))
+  }
+  
+  val blocker = Blocker.liftExecutionContext(concurrent.ExecutionContext.global)
+  val testResources = createTempDirectory(blocker).map(TestResources)
+
+  protected def process(input: Stream[IO, Windowed[IO, Parsed]],
+                        configProvider: ConfigProvider,
+                        expectedOutputPaths: List[String]): IO[ProcessingOutput] =
+    testResources.use { resources =>
+      val config = configProvider(resources)
+      val args = prepareAppArgs(config)
+
+      for {
+        waitingForCompletionMessage <- Deferred[IO, String]
+        runningApp                  <- TestApplication.run(args, waitingForCompletionMessage, input).start
+        completionMessage           <- waitingForCompletionMessage.get
+        _                           <- runningApp.cancel
+        createdDirectories          <- readDirectoriesFrom(resources.outputRootDirectory, expectedOutputPaths)
+      } yield ProcessingOutput(resources.outputRootDirectory, completionMessage, createdDirectories)
+    }
+
+  protected def assertOutputLines(directoryWithActualData: String,
+                                  expectedResource: String,
+                                  createdDirectories: CreatedDirectories) = {
+    val expectedLines = FileUtils.readLines(blocker, expectedResource).unsafeRunSync
+    createdDirectories(directoryWithActualData) must beEqualTo(expectedLines)
+  }
+
+  protected def assertCompletionMessage(result: ProcessingOutput,
+                                        expectedResource: String) = {
+    val expectedMessage = FileUtils
+      .readLines(blocker, expectedResource)
+      .map(_.mkString)
+      .map(
+        _
+          .replace("output_path_placeholder", result.outputRootDirectory.toUri.toString)
+          .replace("version_placeholder", BuildInfo.version)
+          .replace(" ", "")
+      )
+      .unsafeRunSync
+
+    result.completionMessage must beEqualTo(expectedMessage)
+  }
+
+  private def prepareAppArgs(config: TransformerConfig) = {
+    val encoder = Base64.getUrlEncoder
+
+    List(
+      "--iglu-config", new String(encoder.encode(config.iglu.getBytes)),
+      "--config", new String(encoder.encode(config.app.getBytes))
+    )
+  }
+
+  private def readDirectoriesFrom(rootDirectory: Path, 
+                                  children: List[String]): IO[CreatedDirectories] = {
+    children.traverse { child =>
+      readRowsFrom(rootDirectory, child)
+        .map(rows => (child, rows))
+    }
+      .map(_.toMap)
+  }
+
+  private def readRowsFrom(outputDirectory: Path, childDirectory: String): IO[OutputRows] = {
+    val fullPath = Path.of(outputDirectory.toString, childDirectory)
+    directoryStream(blocker, fullPath).compile.toList
+  }
+
+}
+
+object BaseProcessingSpec {
+
+  type ConfigProvider = TestResources => TransformerConfig
+  type CreatedDirectories = Map[String, OutputRows]
+  type OutputRows = List[String]
+
+  final case class TestResources(outputRootDirectory: Path)
+  final case class TransformerConfig(app: String, iglu: String)
+
+  final case class ProcessingOutput(outputRootDirectory: Path,
+                                    completionMessage: String,
+                                    createdDirectories: CreatedDirectories)
+}

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/InputEventsProvider.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/InputEventsProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing
+
+import cats.effect.{ContextShift, IO}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.FileUtils
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.Processing.Windowed
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.TransformingSpec.testBlocker
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.Window
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generic.Record
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sources.{Parsed, file => FileSource}
+import fs2.Stream
+
+
+object InputEventsProvider {
+
+  def eventStream(inputEventsPath: String,
+                  currentWindow: Window,
+                  nextWindow: Window)
+                 (implicit cs: ContextShift[IO]): Stream[IO, Windowed[IO, Parsed]] = {
+    val dataRecords = FileUtils.resourceFileStream(testBlocker, inputEventsPath)
+      .map(FileSource.parse)
+      .map(Record.Data[IO, Window, Parsed](currentWindow, Option.empty, _))
+
+    val endingWindow = Stream.emit(Record.EndWindow[IO, Window, Parsed](currentWindow, nextWindow, IO.pure(())))
+    dataRecords ++ endingWindow
+  }
+}

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/ShredTsvProcessingSpec.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/ShredTsvProcessingSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing
+
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing.BaseProcessingSpec.{ConfigProvider, TransformerConfig}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing.ShredTsvProcessingSpec.{appConfig, igluConfig}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.Window
+
+import java.nio.file.Path
+
+class ShredTsvProcessingSpec extends BaseProcessingSpec {
+
+  val `window-10:30` = Window(1970, 1, 1, 10, 30)
+  val `window-10:31` = Window(1970, 1, 1, 10, 31)
+
+  "Streaming transformer" should {
+    "process items correctly in shred tsv format" in {
+      val configProvider: ConfigProvider = resources => TransformerConfig(appConfig(resources.outputRootDirectory), igluConfig)
+
+      val inputStream = InputEventsProvider.eventStream(
+        inputEventsPath = "/processing-spec/1/input/events",
+        currentWindow   = `window-10:30`,
+        nextWindow      = `window-10:31`
+      )
+
+      //output directories
+      val atomic          = "run=1970-01-01-10-30-00/output=good/vendor=com.snowplowanalytics.snowplow/name=atomic/format=tsv/model=1"
+      val optimizely      = "run=1970-01-01-10-30-00/output=good/vendor=com.optimizely/name=state/format=tsv/model=1"
+      val consentDocument = "run=1970-01-01-10-30-00/output=good/vendor=com.snowplowanalytics.snowplow/name=consent_document/format=tsv/model=1"
+      val bad             = "run=1970-01-01-10-30-00/output=bad/vendor=com.snowplowanalytics.snowplow.badrows/name=loader_parsing_error/format=json/model=2/"
+      
+      val outputDirectoriesToRead = List(atomic, optimizely, consentDocument, bad)
+      val result = process(inputStream, configProvider, outputDirectoriesToRead).unsafeRunSync()
+      
+      assertOutputLines(directoryWithActualData = atomic,          expectedResource = "/processing-spec/1/output/good/tsv/com.snowplowanalytics.snowplow-atomic",           result.createdDirectories)
+      assertOutputLines(directoryWithActualData = optimizely,      expectedResource = "/processing-spec/1/output/good/tsv/com.optimizely-state",                            result.createdDirectories)
+      assertOutputLines(directoryWithActualData = consentDocument, expectedResource = "/processing-spec/1/output/good/tsv/com.snowplowanalytics.snowplow-consent_document", result.createdDirectories)
+      assertOutputLines(directoryWithActualData = bad,             expectedResource = "/processing-spec/1/output/bad",                                                      result.createdDirectories)
+
+      assertCompletionMessage(result, "/processing-spec/1/output/good/tsv/completion.json")
+    }
+  }
+}
+
+object ShredTsvProcessingSpec {
+  private val appConfig = (outputPath: Path) => {
+    s"""|{
+        | "input": {
+        |   "type": "file"
+        |   "dir": "notUsed"
+        | }
+        | "output": {
+        |   "path": "${outputPath.toUri.toString}"
+        |   "compression": "NONE"
+        |   "region": "eu-central-1"
+        | }
+        | "queue": {
+        |   "type": "SQS"
+        |   "queueName": "notUsed"
+        |   "region": "eu-central-1"
+        | }
+        | "windowing": "1 minute"
+        | "formats": {
+        |   "transformationType": "shred"
+        |   "default": "TSV"
+        | }
+        |}""".stripMargin
+  }
+
+  private val igluConfig =
+    """|{
+       |  "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0",
+       |  "data": {
+       |    "cacheSize": 500,
+       |    "repositories": [
+       |      {
+       |        "name": "Iglu Central",
+       |        "priority": 0,
+       |        "vendorPrefixes": [
+       |          "com.snowplowanalytics"
+       |        ],
+       |        "connection": {
+       |          "http": {
+       |            "uri": "http://iglucentral.com"
+       |          }
+       |        }
+       |      }
+       |    ]
+       |  }
+       |}""".stripMargin
+}
+
+

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/TestApplication.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/TestApplication.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing
+
+import cats.effect.concurrent.Deferred
+import cats.effect.{Clock, ContextShift, IO, Sync, Timer}
+import com.snowplowanalytics.aws.AWSQueue
+import com.snowplowanalytics.snowplow.rdbloader.common.config.ShredderCliConfig
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.Processing.Windowed
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sources.Parsed
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.{Processing, Resources}
+import fs2.Stream
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object TestApplication {
+
+  private def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
+
+  def run(args: Seq[String],
+          forCompletionMessage: Deferred[IO, String],
+          windowedRecords: Stream[IO, Windowed[IO, Parsed]])
+         (implicit CS: ContextShift[IO], T: Timer[IO], C: Clock[IO]): IO[Unit] =
+    for {
+      parsed <- ShredderCliConfig.Stream.loadConfigFrom[IO]("Streaming transformer", "Test app")(args).value
+      res <- parsed match {
+        case Right(cliConfig) =>
+         Resources.mk[IO](cliConfig.igluConfig, queueFromDeferred(forCompletionMessage))
+          .use { resources =>
+            logger[IO].info(s"Starting RDB Shredder with ${cliConfig.config} config") *>
+              Processing.runWindowed[IO](windowedRecords, resources, cliConfig.config)
+          }
+        case Left(e) =>
+          logger[IO].error(s"Configuration error: $e")
+      }
+    } yield res
+
+
+  private def queueFromDeferred(deferred: Deferred[IO, String]): AWSQueue[IO] = new AWSQueue[IO] {
+    override def sendMessage(groupId: Option[String], message: String): IO[Unit] = {
+      deferred.complete(message)
+    }
+  }
+}

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/WiderowJsonProcessingSpec.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/WiderowJsonProcessingSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing
+
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing.BaseProcessingSpec.{ConfigProvider, TransformerConfig}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.processing.WiderowJsonProcessingSpec.{appConfig, igluConfig}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.Window
+
+import java.nio.file.Path
+
+class WiderowJsonProcessingSpec extends BaseProcessingSpec {
+
+  val `window-10:30` = Window(1970, 1, 1, 10, 30)
+  val `window-10:31` = Window(1970, 1, 1, 10, 31)
+
+  "Streaming transformer" should {
+    "process items correctly in widerow json format" in {
+      val configProvider: ConfigProvider = resources => TransformerConfig(appConfig(resources.outputRootDirectory), igluConfig)
+
+      val inputStream = InputEventsProvider.eventStream(
+        inputEventsPath = "/processing-spec/1/input/events",
+        currentWindow   = `window-10:30`,
+        nextWindow      = `window-10:31`
+      )
+
+      //output directories
+      val good = "run=1970-01-01-10-30-00/output=good"
+      val bad  = "run=1970-01-01-10-30-00/output=bad"
+      
+      val outputDirectoriesToRead = List(good, bad)
+      val result = process(inputStream, configProvider, outputDirectoriesToRead).unsafeRunSync()
+      
+      assertOutputLines(directoryWithActualData = good, expectedResource = "/processing-spec/1/output/good/widerow/events", result.createdDirectories)
+      assertOutputLines(directoryWithActualData = bad,  expectedResource = "/processing-spec/1/output/bad",                 result.createdDirectories)
+      
+      assertCompletionMessage(result, "/processing-spec/1/output/good/widerow/completion.json")
+    }
+  }
+}
+
+object WiderowJsonProcessingSpec {
+
+  private val appConfig = (outputPath: Path) => {
+    s"""|{
+        | "input": {
+        |   "type": "file"
+        |   "dir": "notUsed"
+        | }
+        | "output": {
+        |   "path": "${outputPath.toUri.toString}"
+        |   "compression": "NONE"
+        |   "region": "eu-central-1"
+        | }
+        | "queue": {
+        |   "type": "SQS"
+        |   "queueName": "notUsed"
+        |   "region": "eu-central-1"
+        | }
+        | "windowing": "1 minute"
+        | "formats": {
+        |   "transformationType": "widerow"
+        |   "fileFormat": "json"
+        | }
+        |}""".stripMargin
+  }
+
+  private val igluConfig =
+    """|{
+       |  "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0",
+       |  "data": {
+       |    "cacheSize": 500,
+       |    "repositories": [
+       |      {
+       |        "name": "Iglu Central",
+       |        "priority": 0,
+       |        "vendorPrefixes": [
+       |          "com.snowplowanalytics"
+       |        ],
+       |        "connection": {
+       |          "http": {
+       |            "uri": "http://iglucentral.com"
+       |          }
+       |        }
+       |      }
+       |    ]
+       |  }
+       |}""".stripMargin
+}

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/TransformingSpec.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/TransformingSpec.scala
@@ -43,8 +43,8 @@ import com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks.generi
 
 import org.specs2.mutable.Specification
 
-class ProcessingSpec extends Specification {
-  import ProcessingSpec._
+class TransformingSpec extends Specification {
+  import TransformingSpec._
   "transform" should {
     "shred events correctly" in {
       val (good, bad) = transformTestEvents(resourcePath = "/processing-spec/1/input/events", format = shredFormat)
@@ -96,7 +96,7 @@ class ProcessingSpec extends Specification {
   }
 }
 
-object ProcessingSpec {
+object TransformingSpec {
   type TransformedList = List[(Transformed.Path, Transformed.Data)]
   type TransformedMap = Map[Transformed.Path.Shredded, List[String]]
 


### PR DESCRIPTION
Currently tests in `transformer-kinesis` module target specific units of code like: transforming, keyed enqueue or partitioning. This PR contains sample tests for almost whole processing pipeline. Almost, because input records are not loaded by pipeline from source (file or kinesis) but created manually in specs, so no windowing in tests (yet).

The pattern used in tests:

* Create input data stream - load events from resources and 'wrap' in specified window.
* Run processing pipeline.
* Wait for completion message for window (using `Deferred` as a custom 'queue' for message). 
* Assert message structure and created output files.

Key code changes:

* Refactored `Resources`, added option to add custom queue (for `Deferred` in tests).
* Added `runWindowed` method used  as an entry to `Processing` for tests. 
* `BaseSpec` contains common steps of tests - run + read output.
* `ShredTsvProcessingSpec` and `WiderowJsonProcessingSpec` sample tests for shred + tsv and widerow + json configurations. 