### PR TITLE
Transformer kinesis: write shredding_complete.json to S3 (close #867)

### DIFF
--- a/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/Main.scala
+++ b/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2021 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -32,7 +32,12 @@ object Main extends IOApp {
       parsed <- ShredderCliConfig.Stream.loadConfigFrom[IO](BuildInfo.name, BuildInfo.description)(args: Seq[String]).value
       res <- parsed match {
         case Right(cliConfig) =>
-          Resources.mk[IO](cliConfig.igluConfig, cliConfig.config.queue, cliConfig.config.monitoring.metrics).use { resources =>
+          Resources.mk[IO](
+            cliConfig.igluConfig,
+            cliConfig.config.queue,
+            cliConfig.config.monitoring.metrics,
+            cliConfig.config.output.path
+          ).use { resources =>
             logger[IO].info(s"Starting RDB Shredder with ${cliConfig.config} config") *>
               Processing.run[IO](resources, cliConfig.config)
                 .merge(resources.metrics.report)

--- a/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/file.scala
+++ b/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/file.scala
@@ -1,9 +1,22 @@
+/*
+ * Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks
 
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{Path => NioPath, Paths}
 
 import cats.data.Chain
+import cats.implicits._
 
 import cats.effect._
 
@@ -11,17 +24,27 @@ import fs2.{Stream, Pipe}
 import fs2.text.utf8Encode
 import fs2.compression.gzip
 
-import com.snowplowanalytics.snowplow.rdbloader.common.config.TransformerConfig.Compression
-
+import blobstore.Store
 import blobstore.fs.FileStore
-import blobstore.BasePath
+import blobstore.{BasePath, Path}
+
+import com.snowplowanalytics.snowplow.rdbloader.common.config.TransformerConfig.Compression
 import com.snowplowanalytics.snowplow.rdbloader.common.transformation.Transformed
 
 object file {
 
-  def getSink[F[_]: Concurrent: ContextShift](blocker: Blocker, root: URI, compression: Compression, counter: Window => F[Int])
-                                             (window: Window)
-                                             (path: Transformed.Path): Pipe[F, Transformed.Data, Unit] = {
+  def initStore[F[_]: Concurrent: ContextShift](blocker: Blocker, outputPath: URI): Store[F] =
+    FileStore[F](Paths.get(outputPath), blocker)
+
+  def getSink[F[_]: Concurrent: ContextShift](
+    store: Store[F],
+    compression: Compression,
+    counter: Window => F[Int]
+  )(
+    window: Window
+  )(
+    path: Transformed.Path
+  ): Pipe[F, Transformed.Data, Unit] = {
     val p = BasePath.empty
       .withPathFromRoot(Chain.fromSeq(s"${window.getDir}/${path.getDir}".split("/")).filter(_.nonEmpty))
       .withIsDir(Some(false))
@@ -32,11 +55,24 @@ object file {
     }
 
     def sink(id: Int): Pipe[F, Byte, Unit] =
-      FileStore[F](Paths.get(root), blocker).put(p.withFileName(Some(s"data-$id.$extension")), false)
+      store.put(p.withFileName(Some(s"data-$id.$extension")), false)
 
     in =>
       Stream.eval(counter(window)).flatMap { id =>
         in.map(_.value).intersperse("\n").through(utf8Encode[F]).through(finalPipe).through(sink(id))
       }
   }
+
+  def writeFile[F[_]: Concurrent: ContextShift](
+    store: Store[F],
+    outputPath: URI,
+    filePath: String,
+    content: String
+  ): F[Unit] =
+    for {
+      relativePath <- Sync[F].delay(Path(NioPath.of(outputPath).relativize(NioPath.of(URI.create(filePath))).toString))
+      pipe = store.put(relativePath)
+      bytes = Stream.emits[F, Byte](content.getBytes)
+      _ <- bytes.through(pipe).compile.drain
+    } yield ()
 }

--- a/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/s3.scala
+++ b/modules/transformer-kinesis/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/sinks/s3.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2021-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.snowplow.rdbloader.transformer.kinesis.sinks
 
 import cats.implicits._
@@ -8,16 +20,19 @@ import fs2.{Stream, Pipe}
 import fs2.text.utf8Encode
 import fs2.compression.gzip
 
-import com.snowplowanalytics.snowplow.rdbloader.common.config.TransformerConfig.Compression
-import com.snowplowanalytics.snowplow.rdbloader.common.transformation.Transformed
-
 import blobstore.s3.{S3Path, S3Store}
+import blobstore.Store
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.services.s3.S3AsyncClient
 
+import com.snowplowanalytics.snowplow.rdbloader.common.config.TransformerConfig.Compression
+import com.snowplowanalytics.snowplow.rdbloader.common.transformation.Transformed
+
 object s3 {
-  def init[F[_] : ConcurrentEffect]: F[S3Store[F]] =
+
+  def initStore[F[_] : ConcurrentEffect]: F[Store[F]] =
     for {
       provider <- Sync[F].delay(DefaultCredentialsProvider.builder().build())
       client <- Sync[F].delay(S3AsyncClient.builder().credentialsProvider(provider).httpClient(NettyNioAsyncHttpClient.builder().build()).build())
@@ -29,32 +44,45 @@ object s3 {
     S3Path(bucket, prefixClean ++ window.getDir ++ "/" ++ path.getDir ++ s"sink-$instanceId-${prep(sinkId)}.$extension", None)
   }
 
-  def getSinkWithStore[F[_] : Sync](s3: S3Store[F], bucket: String, prefix: String, compression: Compression, counter: F[Int], instanceId: String)
-                                   (window: Window)
-                                   (path: Transformed.Path): Pipe[F, Transformed.Data, Unit] = {
+  def getSink[F[_]: ConcurrentEffect](
+    store: Store[F],
+    bucket: String,
+    prefix: String,
+    compression: Compression,
+    getSinkId: Window => F[Int],
+    instanceId: String
+  )(
+    window: Window
+  )(
+    path: Transformed.Path
+  ): Pipe[F, Transformed.Data, Unit] = {
     val (finalPipe, extension) = compression match {
       case Compression.None => (identity[Stream[F, Byte]] _, "txt")
       case Compression.Gzip => (gzip(), "txt.gz")
     }
 
     in =>
-      Stream.eval(counter).flatMap { sinkId =>
+      Stream.eval(getSinkId(window)).flatMap { sinkId =>
         in.map(_.value)
           .intersperse("\n")
           .through(utf8Encode[F])
           .through(finalPipe)
-          .through(s3.put(getPath(bucket, prefix, window, path, instanceId, extension, sinkId), false))
+          .through(store.put(getPath(bucket, prefix, window, path, instanceId, extension, sinkId), false))
       }
   }
 
-  def getSink[F[_]: ConcurrentEffect](bucket: String, prefix: String, compression: Compression, getSinkId: Window => F[Int], instanceId: String)
-                                      (window: Window)
-                                      (path: Transformed.Path): Pipe[F, Transformed.Data, Unit] =
-    (in: Stream[F, Transformed.Data]) =>
-      Stream.eval(init[F]).flatMap { store =>
-        in.through(getSinkWithStore(store, bucket, prefix, compression, getSinkId(window), instanceId)(window)(path))
-      }
-
   private def prep(s: Int): String =
     "0".repeat(4 - s.toString.length) ++ s.toString
+
+  def writeFile[F[_]: ConcurrentEffect](
+    store: Store[F],
+    bucket: String,
+    key: String,
+    content: String
+  ): F[Unit] = {
+    val s3Path = S3Path(bucket, key, None)
+    val pipe = store.put(s3Path)
+    val bytes = Stream.emits[F, Byte](content.getBytes)
+    bytes.through(pipe).compile.drain
+  }
 }

--- a/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/tsv/completion.json
+++ b/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/tsv/completion.json
@@ -1,7 +1,7 @@
 {
   "schema": "iglu:com.snowplowanalytics.snowplow.storage.rdbloader/shredding_complete/jsonschema/2-0-0",
   "data": {
-    "base": "s3://output_path_placeholder/run=1970-01-01-10-30-00/",
+    "base": "output_path_placeholder/run=1970-01-01-10-30-00/",
     "typesInfo": {
       "transformation": "SHREDDED",
       "types": [

--- a/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/widerow/completion.json
+++ b/modules/transformer-kinesis/src/test/resources/processing-spec/1/output/good/widerow/completion.json
@@ -1,7 +1,7 @@
 {
   "schema": "iglu:com.snowplowanalytics.snowplow.storage.rdbloader/shredding_complete/jsonschema/2-0-0",
   "data": {
-    "base": "s3://output_path_placeholder/run=1970-01-01-10-30-00/",
+    "base": "output_path_placeholder/run=1970-01-01-10-30-00/",
     "typesInfo": {
       "transformation": "WIDEROW",
       "fileFormat": "JSON",

--- a/modules/transformer-kinesis/src/test/resources/processing-spec/3/output/completion.json
+++ b/modules/transformer-kinesis/src/test/resources/processing-spec/3/output/completion.json
@@ -1,7 +1,7 @@
 {
   "schema": "iglu:com.snowplowanalytics.snowplow.storage.rdbloader/shredding_complete/jsonschema/2-0-0",
   "data": {
-    "base": "s3://output_path_placeholder/run=1970-01-01-10-30-00/",
+    "base": "output_path_placeholder/run=1970-01-01-10-30-00/",
     "typesInfo": {
       "transformation": "SHREDDED",
       "types": []

--- a/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/TestApplication.scala
+++ b/modules/transformer-kinesis/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/kinesis/processing/TestApplication.scala
@@ -36,7 +36,12 @@ object TestApplication {
       parsed <- ShredderCliConfig.Stream.loadConfigFrom[IO]("Streaming transformer", "Test app")(args).value
       res <- parsed match {
         case Right(cliConfig) =>
-         Resources.mk[IO](cliConfig.igluConfig, queueFromDeferred(forCompletionMessage), cliConfig.config.monitoring.metrics)
+          Resources.mk[IO](
+            cliConfig.igluConfig,
+            queueFromDeferred(forCompletionMessage),
+            cliConfig.config.monitoring.metrics,
+            cliConfig.config.output.path
+          )
           .use { resources =>
             logger[IO].info(s"Starting RDB Shredder with ${cliConfig.config} config") *>
               Processing.runWindowed[IO](windowedRecords, resources, cliConfig.config)


### PR DESCRIPTION
I resisted the temptation to update `LoaderMessage.ShreddingComplete(base: S3.Folder` (because `shredding_complete.json` has nothing to do with S3 when we work locally), but that involves quite a lot of refactoring, as this is used in batch shredder and loaders as well, so I leave it until we add GCP support to the transformer and we have no choice but doing this refactoring.