### PR TITLE
Update Databricks.scala

### DIFF
--- a/modules/databricks-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/databricks/Databricks.scala
+++ b/modules/databricks-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/databricks/Databricks.scala
@@ -111,6 +111,7 @@ object Databricks {
                         SELECT $frSelectColumns from '$frPath' $frAuth
                       )
                       FILEFORMAT = PARQUET
+                      FORMAT_OPTIONS('MERGESCHEMA' = 'TRUE')
                       COPY_OPTIONS('MERGESCHEMA' = 'TRUE')""";
               case _: Statement.ShreddedCopy =>
                 throw new IllegalStateException("Databricks Loader does not support migrations")


### PR DESCRIPTION
We have an issue where we read data from multiple parquet files with different schemas (optional column only exist in some of the files). It generates the following exception in Databricks: `com.databricks.backend.common.rpc.SparkDriverExceptions$SQLExecutionException: org.apache.spark.sql.AnalysisException: [MISSING_COLUMN] Column 'unstruct_event_com_lego_3dcatalogue_like_product_1' does not exist. Did you mean one of the following?`

Recreating the issue in Databricks within a notebook and testing different options revealed we had to add the FORMAT_OPTIONS with mergeSchema to fix the issue.