### PR TITLE
Stop loader getting stuck on rollback

### DIFF
--- a/modules/databricks-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/databricks/DatabricksSpec.scala
+++ b/modules/databricks-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/databricks/DatabricksSpec.scala
@@ -168,7 +168,7 @@ object DatabricksSpec {
         Config.Monitoring(None, None, Config.Metrics(None, None, 1.minute), None, None, None),
         None,
         Config.Schedules(Nil),
-        Config.Timeouts(1.minute, 1.minute, 1.minute),
+        Config.Timeouts(1.minute, 1.minute, 1.minute, 1.minute),
         Config.Retries(Config.Strategy.Constant, None, 1.minute, None),
         Config.Retries(Config.Strategy.Constant, None, 1.minute, None),
         Config.Retries(Config.Strategy.Constant, None, 1.minute, None),

--- a/modules/loader/src/main/resources/application.conf
+++ b/modules/loader/src/main/resources/application.conf
@@ -32,7 +32,8 @@
     "timeouts": {
         "loading": "1 hour",
         "nonLoading": "10 minutes",
-        "sqsVisibility": "5 minutes"
+        "sqsVisibility": "5 minutes",
+        "rollbackCommit": "20 minutes"
     },
     "featureFlags": {
         "addLoadTstampColumn": true

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/config/Config.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/config/Config.scala
@@ -118,7 +118,8 @@ object Config {
   final case class Timeouts(
     loading: FiniteDuration,
     nonLoading: FiniteDuration,
-    sqsVisibility: FiniteDuration
+    sqsVisibility: FiniteDuration,
+    rollbackCommit: FiniteDuration
   )
   final case class Retries(
     strategy: Strategy,

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/config/StorageTarget.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/config/StorageTarget.scala
@@ -26,6 +26,7 @@ import doobie.util.transactor.Strategy
 
 import com.snowplowanalytics.snowplow.rdbloader.common.config.StringEnum
 import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage
+import com.snowplowanalytics.snowplow.rdbloader.dsl.Transaction
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -38,7 +39,7 @@ sealed trait StorageTarget extends Product with Serializable {
   def password: StorageTarget.PasswordConfig
   def sshTunnel: Option[StorageTarget.TunnelConfig]
 
-  def doobieCommitStrategy: Strategy = Strategy.default
+  def doobieCommitStrategy(rollbackCommitTimeout: FiniteDuration): Strategy = Transaction.defaultStrategy(rollbackCommitTimeout)
 
   /**
    * Surprisingly, for statements disallowed in transaction block we need to set autocommit
@@ -124,7 +125,7 @@ object StorageTarget {
 
     override def connectionUrl: String = s"jdbc:databricks://$host:$port"
 
-    override def doobieCommitStrategy: Strategy = Strategy.void
+    override def doobieCommitStrategy(t: FiniteDuration): Strategy = Strategy.void
     override def doobieNoCommitStrategy: Strategy = Strategy.void
     override def withAutoCommit = true
 

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
@@ -112,7 +112,7 @@ object Environment {
       implicit0(monitoring: Monitoring[F]) =
         Monitoring.monitoringInterpreter[F](tracker, sentry, reporters, cli.config.monitoring.webhook, httpClient, periodicMetrics)
       implicit0(secretStore: SecretStore[F]) = cloudServices.secretStore
-      transaction <- Transaction.interpreter[F](cli.config.storage, blocker)
+      transaction <- Transaction.interpreter[F](cli.config.storage, cli.config.timeouts, blocker)
       telemetry <- Telemetry.build[F](
                      cli.config.telemetry,
                      appName,

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/StateMonitoring.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/StateMonitoring.scala
@@ -128,6 +128,8 @@ object StateMonitoring {
   ): Boolean = {
     val lastUpdated = state.updated
     val passed = (now.toEpochMilli - lastUpdated.toEpochMilli).milli
-    if (isLoading(state.loading)) passed > timeouts.loading else passed > timeouts.nonLoading
+    val timeout = if (isLoading(state.loading)) timeouts.loading else timeouts.nonLoading
+    // Rollback/Commit can be used in all statements therefore their timeout should be added in all cases
+    passed > (timeout + timeouts.rollbackCommit)
   }
 }

--- a/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/ConfigSpec.scala
+++ b/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/ConfigSpec.scala
@@ -167,7 +167,7 @@ object ConfigSpec {
   )
   val defaultSchedules: Config.Schedules =
     Config.Schedules(Nil, Some(Cron.unsafeParse("0 0 0 ? * *")), Some(Cron.unsafeParse("0 0 5 ? * *")))
-  val exampleTimeouts: Config.Timeouts = Config.Timeouts(1.hour, 10.minutes, 5.minutes)
+  val exampleTimeouts: Config.Timeouts = Config.Timeouts(1.hour, 10.minutes, 5.minutes, 20.minutes)
   val exampleRetries: Config.Retries = Config.Retries(Config.Strategy.Exponential, Some(3), 30.seconds, Some(1.hour))
   val exampleReadyCheck: Config.Retries = Config.Retries(Config.Strategy.Constant, None, 15.seconds, None)
   val exampleTempCreds = StorageTarget.LoadAuthMethod.TempCreds("test_role_arn", "test_role_session_name")


### PR DESCRIPTION
If a query ends with a `SQLTimeoutException`, we have seen the loader occasionally gets stuck in the phases after this exception.  We suspect it's getting stuck while doing a rollback.

This PR is a demo of one way we could stop the loader from getting stuck on the automatic rollback.  It works by changing the `oops` method of [a doobie commit strategy](https://github.com/tpolecat/doobie/blob/v0.13.4/modules/core/src/main/scala/doobie/util/transactor.scala#L43) so there is an explicit timeout on the rollback.

If you like this change there are a couple of extra things we should do to make it production ready:

- Amend `StateMonitoring` so it allows extra time for this rollback timeout
- Make the timeout configurable.  We can re-use the existing `timeouts.nonLoading` config parameter.