### PR TITLE
Databricks Loader: use recommended query to create folder_monitoring …

### DIFF
--- a/modules/databricks-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/databricks/Databricks.scala
+++ b/modules/databricks-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/databricks/Databricks.scala
@@ -93,13 +93,10 @@ object Databricks {
               case Statement.Select1 => sql"SELECT 1"
               case Statement.ReadyCheck => sql"SELECT 1"
 
-              case Statement.CreateAlertingTempTable =>
+              case Statement.CreateOrReplaceAlertingTempTable =>
                 val frTableName = Fragment.const(qualify(AlertingTempTableName))
                 // It is not possible to create temp table in Databricks
-                sql"CREATE TABLE IF NOT EXISTS $frTableName ( run_id VARCHAR(512) )"
-              case Statement.DropAlertingTempTable =>
-                val frTableName = Fragment.const(qualify(AlertingTempTableName))
-                sql"DROP TABLE IF EXISTS $frTableName"
+                sql"CREATE OR REPLACE TABLE $frTableName ( run_id VARCHAR(512) )"
               case Statement.FoldersMinusManifest =>
                 val frTableName = Fragment.const(qualify(AlertingTempTableName))
                 val frManifest = Fragment.const(qualify(Manifest.Name))

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
@@ -48,8 +48,7 @@ object Statement {
   case object ReadyCheck extends Statement
 
   // Alerting
-  case object CreateAlertingTempTable extends Statement
-  case object DropAlertingTempTable extends Statement
+  case object CreateOrReplaceAlertingTempTable extends Statement
   case object FoldersMinusManifest extends Statement
   case class FoldersCopy[T](
     source: BlobStorage.Folder,

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/FolderMonitoring.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/FolderMonitoring.scala
@@ -182,8 +182,7 @@ object FolderMonitoring {
     initQueryResult: I
   ): F[List[AlertPayload]] = {
     val getBatches = for {
-      _ <- DAO[C].executeUpdate(DropAlertingTempTable, DAO.Purpose.NonLoading)
-      _ <- DAO[C].executeUpdate(CreateAlertingTempTable, DAO.Purpose.NonLoading)
+      _ <- DAO[C].executeUpdate(CreateOrReplaceAlertingTempTable, DAO.Purpose.NonLoading)
       _ <- DAO[C].executeUpdate(FoldersCopy(loadFrom, loadAuthMethod, initQueryResult), DAO.Purpose.NonLoading)
       onlyS3Batches <- DAO[C].executeQueryList[BlobStorage.Folder](FoldersMinusManifest)
     } yield onlyS3Batches

--- a/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/FolderMonitoringSpec.scala
+++ b/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/FolderMonitoringSpec.scala
@@ -41,8 +41,7 @@ class FolderMonitoringSpec extends Specification {
           PureTransaction.CommitMessage,
           TestState.LogEntry.Sql(Statement.FoldersMinusManifest),
           TestState.LogEntry.Sql(Statement.FoldersCopy(BlobStorage.Folder.coerce("s3://bucket/shredded/"), LoadAuthMethod.NoCreds, ())),
-          TestState.LogEntry.Sql(Statement.CreateAlertingTempTable),
-          TestState.LogEntry.Sql(Statement.DropAlertingTempTable),
+          TestState.LogEntry.Sql(Statement.CreateOrReplaceAlertingTempTable),
           PureTransaction.StartMessage,
           TestState.LogEntry.Sql(Statement.ReadyCheck),
           PureTransaction.NoTransactionMessage
@@ -82,8 +81,7 @@ class FolderMonitoringSpec extends Specification {
           PureTransaction.CommitMessage,
           TestState.LogEntry.Sql(Statement.FoldersMinusManifest),
           TestState.LogEntry.Sql(Statement.FoldersCopy(BlobStorage.Folder.coerce("s3://bucket/shredded/"), LoadAuthMethod.NoCreds, ())),
-          TestState.LogEntry.Sql(Statement.CreateAlertingTempTable),
-          TestState.LogEntry.Sql(Statement.DropAlertingTempTable),
+          TestState.LogEntry.Sql(Statement.CreateOrReplaceAlertingTempTable),
           PureTransaction.StartMessage,
           TestState.LogEntry.Sql(Statement.ReadyCheck),
           PureTransaction.NoTransactionMessage

--- a/modules/redshift-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/redshift/Redshift.scala
+++ b/modules/redshift-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/redshift/Redshift.scala
@@ -119,12 +119,9 @@ object Redshift {
               case Statement.Select1 => sql"SELECT 1"
               case Statement.ReadyCheck => sql"SELECT 1"
 
-              case Statement.CreateAlertingTempTable =>
+              case Statement.CreateOrReplaceAlertingTempTable =>
                 val frTableName = Fragment.const(AlertingTempTableName)
-                sql"CREATE TEMPORARY TABLE $frTableName ( run_id VARCHAR(512) )"
-              case Statement.DropAlertingTempTable =>
-                val frTableName = Fragment.const(AlertingTempTableName)
-                sql"DROP TABLE IF EXISTS $frTableName"
+                sql"DROP TABLE IF EXISTS $frTableName; CREATE TEMPORARY TABLE $frTableName ( run_id VARCHAR(512) )"
               case Statement.FoldersMinusManifest =>
                 val frTableName = Fragment.const(AlertingTempTableName)
                 val frManifest = Fragment.const(s"${schema}.manifest")

--- a/modules/snowflake-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/snowflake/Snowflake.scala
+++ b/modules/snowflake-loader/src/main/scala/com/snowplowanalytics/snowplow/loader/snowflake/Snowflake.scala
@@ -129,12 +129,9 @@ object Snowflake {
               case Statement.Select1 => sql"SELECT 1" // OK
               case Statement.ReadyCheck => sql"ALTER WAREHOUSE ${Fragment.const0(tgt.warehouse)} RESUME IF SUSPENDED"
 
-              case Statement.CreateAlertingTempTable => // OK
+              case Statement.CreateOrReplaceAlertingTempTable => // OK
                 val frTableName = Fragment.const(qualify(AlertingTempTableName))
-                sql"CREATE TEMPORARY TABLE $frTableName ( run_id VARCHAR )"
-              case Statement.DropAlertingTempTable =>
-                val frTableName = Fragment.const(qualify(AlertingTempTableName))
-                sql"DROP TABLE IF EXISTS $frTableName"
+                sql"DROP TABLE IF EXISTS $frTableName; CREATE TEMPORARY TABLE $frTableName ( run_id VARCHAR )"
               case Statement.FoldersMinusManifest =>
                 val frTableName = Fragment.const(qualify(AlertingTempTableName))
                 val frManifest = Fragment.const(qualify(Manifest.Name))


### PR DESCRIPTION
…table

Use the Databricks recommended* 'CREATE OR REPLACE TABLE' query to create the rdb_folder_monitoring table

*https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-create-table-using.html