### PR TITLE
Azure: blob storage improvements

### DIFF
--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Config.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Config.scala
@@ -291,12 +291,12 @@ object Config {
             cur.as[Output.S3]
           case Right("gs") =>
             cur.as[Output.GCS]
-          case Right("https") =>
+          case Right("http") | Right("https") =>
             cur.as[Output.AzureBlobStorage]
           case Right(other) =>
             Left(
               DecodingFailure(
-                s"Output type $other is not supported yet. Supported types: 's3', 's3a', 's3n', 'gs', 'https'",
+                s"Output type $other is not supported yet. Supported types: 's3', 's3a', 's3n', 'gs', 'http', 'https'",
                 pathCur.history
               )
             )

--- a/modules/common-transformer-stream/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/processing/TestApplication.scala
+++ b/modules/common-transformer-stream/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/processing/TestApplication.scala
@@ -159,7 +159,7 @@ object TestApplication {
     val updatedOutput = config.output match {
       case c: Config.Output.S3 => c.copy(path = URI.create(c.path.toString.replace("s3:/", "file:/")))
       case c: Config.Output.GCS => c.copy(path = URI.create(c.path.toString.replace("gs:/", "file:/")))
-      case c: Config.Output.AzureBlobStorage => c.copy(path = URI.create(c.path.toString.replace("https:/", "file:/")))
+      case c: Config.Output.AzureBlobStorage => c.copy(path = URI.create(c.path.toString.replace("http:/", "file:/")))
     }
     config.copy(output = updatedOutput)
   }

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/common/cloud/BlobStorage.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/common/cloud/BlobStorage.scala
@@ -88,7 +88,7 @@ object BlobStorage {
   object Folder extends tag.Tagger[BlobStorageFolderTag] {
 
     def parse(s: String): Either[String, Folder] = s match {
-      case _ if !correctlyPrefixed(s) => s"Bucket name $s doesn't start with s3:// s3a:// s3n:// gs:// or https:// prefix".asLeft
+      case _ if !correctlyPrefixed(s) => s"Bucket name $s doesn't start with s3:// s3a:// s3n:// gs:// http:// or https:// prefix".asLeft
       case _ if s.length > 1024 => "Key length cannot be more than 1024 symbols".asLeft
       case _ => coerce(s).asRight
     }
@@ -117,7 +117,7 @@ object BlobStorage {
    * Extract `xx://path/run=YYYY-MM-dd-HH-mm-ss/atomic-events` part from Set of prefixes that can be
    * used in config.yml In the end it won't affect how blob storage is accessed
    */
-  val supportedPrefixes = Set("s3", "s3n", "s3a", "gs", "https")
+  val supportedPrefixes = Set("s3", "s3n", "s3a", "gs", "http", "https")
 
   private def correctlyPrefixed(s: String): Boolean =
     supportedPrefixes.foldLeft(false) { (result, prefix) =>
@@ -146,7 +146,7 @@ object BlobStorage {
       fixPrefix(s).asInstanceOf[Key]
 
     def parse(s: String): Either[String, Key] = s match {
-      case _ if !correctlyPrefixed(s) => s"Bucket name $s doesn't start with s3:// s3a:// s3n:// gs:// https:// prefix".asLeft
+      case _ if !correctlyPrefixed(s) => s"Bucket name $s doesn't start with s3:// s3a:// s3n:// gs:// http:// or https:// prefix".asLeft
       case _ if s.length > 1024 => "Key length cannot be more than 1024 symbols".asLeft
       case _ if s.endsWith("/") => "Blob storage key cannot have trailing slash".asLeft
       case _ => coerce(s).asRight

--- a/modules/transformer-kafka/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/Main.scala
+++ b/modules/transformer-kafka/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/Main.scala
@@ -15,12 +15,10 @@
 package com.snowplowanalytics.snowplow.rdbloader.transformer.stream.kafka
 
 import cats.effect._
-import com.snowplowanalytics.snowplow.rdbloader.aws.AzureBlobStorage
-import com.snowplowanalytics.snowplow.rdbloader.azure._
-import com.snowplowanalytics.snowplow.rdbloader.common.cloud.{BlobStorage, Queue}
+import com.snowplowanalytics.snowplow.rdbloader.azure.AzureBlobStorage
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.{Config, Run}
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.kafka.generated.BuildInfo
-
 import com.snowplowanalytics.snowplow.scalatracker.emitters.http4s.ceTracking
 
 object Main extends IOApp {
@@ -32,58 +30,18 @@ object Main extends IOApp {
       BuildInfo.version,
       BuildInfo.description,
       runtime.compute,
-      (config, _) => mkSource(config),
-      c => mkBlobStorage(c),
-      c => mkBadQueue(c),
-      mkShreddingCompleteQueue,
+      (config, _) => Queues.createInputQueue(config),
+      c => createBlobStorage(c),
+      c => Queues.createBadOutputQueue(c),
+      Queues.createShreddingCompleteQueue,
       KafkaCheckpointer.checkpointer
     )
 
-  private def mkSource[F[_]: Async](
-    streamInput: Config.StreamInput
-  ): Resource[F, Queue.Consumer[F]] =
-    streamInput match {
-      case conf: Config.StreamInput.Kafka =>
-        KafkaConsumer.consumer[F](
-          conf.bootstrapServers,
-          conf.topicName,
-          conf.consumerConf
-        )
-      case _ =>
-        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Input is not Kafka")))
-    }
-
-  private def mkBlobStorage[F[_]: Async](output: Config.Output): Resource[F, BlobStorage[F]] =
+  private def createBlobStorage[F[_]: Async](output: Config.Output): Resource[F, BlobStorage[F]] =
     output match {
-      case _: Config.Output.AzureBlobStorage =>
-        AzureBlobStorage.create[F]()
+      case c: Config.Output.AzureBlobStorage =>
+        AzureBlobStorage.createDefault[F](c.path)
       case _ =>
         Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Output is not Azure Blob Storage")))
-    }
-
-  private def mkBadQueue[F[_]: Async](
-    output: Config.Output.Bad.Queue
-  ): Resource[F, Queue.ChunkProducer[F]] =
-    output match {
-      case kafka: Config.Output.Bad.Queue.Kafka =>
-        KafkaProducer.chunkProducer[F](
-          kafka.bootstrapServers,
-          kafka.topicName,
-          kafka.producerConf
-        )
-      case _ =>
-        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Output queue is not Kafka")))
-    }
-
-  private def mkShreddingCompleteQueue[F[_]: Async](queueConfig: Config.QueueConfig): Resource[F, Queue.Producer[F]] =
-    queueConfig match {
-      case kafka: Config.QueueConfig.Kafka =>
-        KafkaProducer.producer[F](
-          kafka.bootstrapServers,
-          kafka.topicName,
-          kafka.producerConf
-        )
-      case _ =>
-        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Message queue is not Kafka")))
     }
 }

--- a/modules/transformer-kafka/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/Queues.scala
+++ b/modules/transformer-kafka/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/Queues.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.stream.kafka
+
+import cats.effect._
+import com.snowplowanalytics.snowplow.rdbloader.azure._
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.Queue
+import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.Config
+
+private[kafka] object Queues {
+
+  def createInputQueue[F[_]: Async](
+    streamInput: Config.StreamInput
+  ): Resource[F, Queue.Consumer[F]] =
+    streamInput match {
+      case conf: Config.StreamInput.Kafka =>
+        KafkaConsumer.consumer[F](
+          conf.bootstrapServers,
+          conf.topicName,
+          conf.consumerConf
+        )
+      case _ =>
+        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Input is not Kafka")))
+    }
+
+  def createBadOutputQueue[F[_]: Async](
+    output: Config.Output.Bad.Queue
+  ): Resource[F, Queue.ChunkProducer[F]] =
+    output match {
+      case kafka: Config.Output.Bad.Queue.Kafka =>
+        KafkaProducer.chunkProducer[F](
+          kafka.bootstrapServers,
+          kafka.topicName,
+          kafka.producerConf
+        )
+      case _ =>
+        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Output queue is not Kafka")))
+    }
+
+  def createShreddingCompleteQueue[F[_]: Async](queueConfig: Config.QueueConfig): Resource[F, Queue.Producer[F]] =
+    queueConfig match {
+      case kafka: Config.QueueConfig.Kafka =>
+        KafkaProducer.producer[F](
+          kafka.bootstrapServers,
+          kafka.topicName,
+          kafka.producerConf
+        )
+      case _ =>
+        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Message queue is not Kafka")))
+    }
+}

--- a/modules/transformer-kafka/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/AzuriteBasedDevApp.scala
+++ b/modules/transformer-kafka/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/kafka/AzuriteBasedDevApp.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2012-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.stream.kafka
+
+import cats.effect._
+import com.azure.storage.blob.BlobServiceClientBuilder
+import com.azure.storage.common.StorageSharedKeyCredential
+import com.snowplowanalytics.snowplow.rdbloader.azure.AzureBlobStorage
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage
+import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.{Config, Run}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.kafka.generated.BuildInfo
+import com.snowplowanalytics.snowplow.scalatracker.emitters.http4s.ceTracking
+
+import java.util.Base64
+
+/**
+ * Test transformer application that can be run locally with local Azure-like resources.
+ *
+ * To run following resources are required:
+ *
+ *   - Kafka cluster (localhost:9092) with two topics: 'enriched' (input) and 'shreddingComplete'
+ *     (for shredding complete message to notify loader)
+ *   - Azurite Blob Storage (http://127.0.0.1:10000/devstoreaccount1) with `transformed` blob
+ *     container created
+ *
+ * In the future it could be converted to automatic integration tests using testcontainers.
+ */
+object AzuriteBasedDevApp extends IOApp {
+
+  val appConfig =
+    """
+      |{
+      |  "input": {
+      |    "topicName": "enriched"
+      |    "bootstrapServers": "localhost:9092"
+      |  }
+      |  "output": {
+      |     "path": "http://127.0.0.1:10000/devstoreaccount1/transformed"
+      |  }
+      |  "windowing": "1 minute"
+      |  
+      |  "queue": {
+      |    "topicName": "shreddingComplete"
+      |    "bootstrapServers": "localhost:9092"
+      |  }
+      |}
+      |""".stripMargin
+
+  val resolverConfig =
+    """
+      |{
+      |  "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0",
+      |  "data": {
+      |    "cacheSize": 500,
+      |    "cacheTtl": 30,
+      |    "repositories": [
+      |      {
+      |        "name": "Iglu Central",
+      |        "priority": 0,
+      |        "vendorPrefixes": [ ],
+      |        "connection": {
+      |          "http": {
+      |            "uri": "http://iglucentral.com"
+      |          }
+      |        }
+      |      }
+      |    ]
+      |  }
+      |}
+      |""".stripMargin
+
+  val credentials = new StorageSharedKeyCredential(
+    "devstoreaccount1",
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+  )
+
+  def run(args: List[String]): IO[ExitCode] = {
+    val fixedArgs = List("--config", encode(appConfig), "--iglu-config", encode(resolverConfig))
+    Run.run[IO, KafkaCheckpointer[IO]](
+      fixedArgs,
+      BuildInfo.name,
+      BuildInfo.version,
+      BuildInfo.description,
+      runtime.compute,
+      (config, _) => Queues.createInputQueue(config),
+      c => createBlobStorageWithAzuriteKeys(c),
+      c => Queues.createBadOutputQueue(c),
+      Queues.createShreddingCompleteQueue,
+      KafkaCheckpointer.checkpointer
+    )
+  }
+
+  private def createBlobStorageWithAzuriteKeys[F[_]: Async](output: Config.Output): Resource[F, BlobStorage[F]] =
+    output match {
+      case c: Config.Output.AzureBlobStorage =>
+        val clientBuilder = new BlobServiceClientBuilder().credential(credentials)
+        AzureBlobStorage.create(c.path, clientBuilder)
+      case _ =>
+        Resource.eval(Async[F].raiseError(new IllegalArgumentException(s"Output is not Azure Blob Storage")))
+    }
+
+  private def encode(value: String) =
+    new String(Base64.getUrlEncoder.encode(value.getBytes("UTF-8")))
+
+}


### PR DESCRIPTION
* Added `endpoint` (scheme://hostname) as a parameter of blob storage creation. Based on that we can extract container and the rest of the blob path.
* Added `AzuriteBasedDevApp` in the test sources, only for development, main purpose is to be able easily launch transformer-kafka using kafka and azurite running locally. 