### PR TITLE
Add auth for writing Parquet data to Azure DataLake

### DIFF
--- a/modules/azure/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureTokenProvider.scala
+++ b/modules/azure/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureTokenProvider.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.azure
+
+import java.util.Date
+
+import com.azure.core.credential.TokenRequestContext
+import com.azure.identity.DefaultAzureCredentialBuilder
+
+import org.apache.hadoop.fs.azurebfs.extensions.CustomTokenProviderAdaptee
+import org.apache.hadoop.conf.Configuration
+
+/**
+ * Creates Azure tokens for using with Hadoop file system. It isn't directly used in the project.
+ * Instead, class name is given as Hadoop configuration in the Main of Transformer Kafka. Then, it
+ * is used by Hadoop Azure File System to generate tokens.
+ */
+class AzureTokenProvider extends CustomTokenProviderAdaptee {
+
+  private var expiryTime: Date = _
+  private var accountName: String = _
+
+  override def initialize(configuration: Configuration, accountName: String): Unit =
+    this.accountName = accountName
+
+  override def getAccessToken: String = {
+    val creds = new DefaultAzureCredentialBuilder().build()
+    val request = new TokenRequestContext()
+    request.addScopes("https://" + accountName)
+    val token = creds.getToken(request).block()
+    this.expiryTime = new Date(token.getExpiresAt.toInstant.toEpochMilli)
+    token.getToken
+  }
+
+  override def getExpiryTime: Date = expiryTime
+}

--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Resources.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Resources.scala
@@ -38,6 +38,7 @@ import com.snowplowanalytics.snowplow.rdbloader.common.cloud.{BlobStorage, Queue
 import com.snowplowanalytics.snowplow.rdbloader.common.telemetry.Telemetry
 import com.snowplowanalytics.snowplow.rdbloader.common.transformation.EventUtils.EventParser
 import com.snowplowanalytics.snowplow.rdbloader.common.transformation.{EventUtils, PropertiesCache, PropertiesKey}
+import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.parquet.ParquetOps
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.Config.Output.Bad
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.metrics.Metrics
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.sinks.BadSink
@@ -59,7 +60,8 @@ case class Resources[F[_], C](
   inputStream: Queue.Consumer[F],
   checkpointer: Queue.Consumer.Message[F] => C,
   blobStorage: BlobStorage[F],
-  badSink: BadSink[F]
+  badSink: BadSink[F],
+  parquetOps: ParquetOps
 )
 
 object Resources {
@@ -76,7 +78,8 @@ object Resources {
     mkSink: Config.Output => Resource[F, BlobStorage[F]],
     mkBadQueue: Config.Output.Bad.Queue => Resource[F, Queue.ChunkProducer[F]],
     mkQueue: Config.QueueConfig => Resource[F, Queue.Producer[F]],
-    checkpointer: Queue.Consumer.Message[F] => C
+    checkpointer: Queue.Consumer.Message[F] => C,
+    parquetOps: ParquetOps
   ): Resource[F, Resources[F, C]] =
     for {
       producer <- mkQueue(config.queue)
@@ -114,7 +117,8 @@ object Resources {
       inputStream,
       checkpointer,
       blobStorage,
-      badSink
+      badSink,
+      parquetOps
     )
 
   private def mkBadSink[F[_]: Applicative](

--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetOps.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetOps.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.parquet
+
+import org.apache.hadoop.conf.Configuration
+
+trait ParquetOps {
+  def transformPath(p: String): String
+  def hadoopConf: Configuration
+}
+
+object ParquetOps {
+  def noop: ParquetOps = new ParquetOps {
+    override def transformPath(p: String): String = p
+    override def hadoopConf: Configuration = new Configuration()
+  }
+}

--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetSink.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetSink.scala
@@ -32,9 +32,9 @@ import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.parque
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.sinks.{SinkPath, TransformedDataOps, Window}
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.Resources
 import fs2.{Pipe, Stream}
+import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.parquet.schema.MessageType
-
 import java.net.URI
 
 object ParquetSink {
@@ -50,14 +50,14 @@ object ParquetSink {
   ): Pipe[F, Transformed.Data, Unit] = { transformedData =>
     // As uri can use 's3a' schema, using methods from 'java.nio.file.Path' would require additional dependency responsible for adding appropriate 'java.nio.file.spi.FileSystemProvider', see e.g. https://github.com/carlspring/s3fs-nio/
     // Simple strings concat works for both cases: uri configured with and without trailing '/', bypassing usage of 'java.nio.file.Path'
-    val targetPath = s"${uri.toString}/${window.getDir}/${path.value}"
+    val targetPath = s"${resources.parquetOps.transformPath(uri.toString)}/${window.getDir}/${path.value}"
     val schemaCreation = createSchemaFromTypes(resources, types).value
 
     Stream.eval(schemaCreation).flatMap {
       case Left(error) =>
         Stream.raiseError[F](new RuntimeException(s"Error while building parquet schema. ${error.show}"))
       case Right(schema) =>
-        val parquetPipe = writeAsParquet(compression, targetPath, maxRecordsPerFile, schema)
+        val parquetPipe = writeAsParquet(compression, targetPath, maxRecordsPerFile, schema, resources.parquetOps.hadoopConf)
 
         transformedData
           .mapFilter(_.fieldValues)
@@ -79,7 +79,8 @@ object ParquetSink {
     compression: Compression,
     path: String,
     maxRecordsPerFile: Long,
-    schema: MessageType
+    schema: MessageType,
+    hadoopConf: Configuration
   ) = {
     implicit val targetSchema = schema
 
@@ -92,7 +93,7 @@ object ParquetSink {
       .of[List[FieldWithValue]]
       .preWriteTransformation(buildParquetRecord)
       .maxCount(maxRecordsPerFile)
-      .options(ParquetWriter.Options(compressionCodecName = compressionCodecName))
+      .options(ParquetWriter.Options(compressionCodecName = compressionCodecName, hadoopConf = hadoopConf))
       .write(Path(path))
   }
 

--- a/modules/common-transformer-stream/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/processing/TestApplication.scala
+++ b/modules/common-transformer-stream/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/processing/TestApplication.scala
@@ -31,6 +31,7 @@ import fs2.{Pipe, Stream}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import cats.effect.unsafe.implicits.global
 import cats.Applicative
+import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.parquet.ParquetOps
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.sources.{Checkpointer, ParsedC}
 import com.snowplowanalytics.snowplow.rdbloader.transformer.stream.common.{CliConfig, Config, Processing, Resources}
 import fs2.io.file.Files
@@ -72,7 +73,8 @@ object TestApplication {
                        mkSink,
                        _ => mkBadQueue[IO](queueBadSink),
                        _ => queueFromRef[IO](completionsRef),
-                       _ => ()
+                       _ => (),
+                       ParquetOps.noop
                      )
                      .use { resources =>
                        logger[IO].info(s"Starting RDB Shredder with ${appConfig} config") *>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,12 +137,13 @@ object Dependencies {
   val jacksonDatabind   = "com.fasterxml.jackson.core"       %  "jackson-databind"         % V.jacksonDatabind
   val jacksonCbor       = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"   % V.jacksonModule
   val parquet4s         = "com.github.mjakubowski84"         %% "parquet4s-fs2"            % V.parquet4s
+  val hadoopCommon      = "org.apache.hadoop"                % "hadoop-common"             % V.hadoopClient
   val hadoop            = "org.apache.hadoop"                % "hadoop-client"             % V.hadoopClient
   val parquetHadoop     = "org.apache.parquet"               % "parquet-hadoop"            % V.parquetHadoop
   val hadoopAws         = ("org.apache.hadoop"               % "hadoop-aws"                % V.hadoopClient % Runtime)
     .exclude("com.amazonaws", "aws-java-sdk-bundle") // aws-java-sdk-core is already present in assembled jar
   val hadoopGcp         = "com.google.cloud.bigdataoss"      % "gcs-connector"             % V.hadoopGcpClient % Runtime
-  val hadoopAzure       = "org.apache.hadoop"                % "hadoop-azure"              % "3.3.5" % Runtime
+  val hadoopAzure       = "org.apache.hadoop"                % "hadoop-azure"              % V.hadoopClient
   val kinesisClient     = ("software.amazon.kinesis"         %  "amazon-kinesis-client"    % V.kinesisClient)
                           .exclude("software.amazon.glue", "schema-registry-common")
                           .exclude("software.amazon.glue", "schema-registry-serde")
@@ -214,7 +215,9 @@ object Dependencies {
   val azureDependencies = Seq(
     fs2BlobstoreAzure,
     azureIdentity,
-    fs2Kafka
+    fs2Kafka,
+    hadoopCommon,
+    hadoopAzure
   )
 
   val commonDependencies = Seq(


### PR DESCRIPTION
This PR adds authentication implementation for writing Parquet data to Azure DataLake. Even though we've already specified `DefaultAzureCredential` as auth method in the `AzureBlobStorage` class, this can't be picked up by Parquet writer since it uses Hadoop to write files. Therefore, we need separate implementation. Implementation details are found from [this page](https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html#Introduction) mostly.