### PR TITLE
Loader: integrate Azure Key Vault

### DIFF
--- a/config/loader/azure/databricks.config.minimal.hocon
+++ b/config/loader/azure/databricks.config.minimal.hocon
@@ -1,5 +1,5 @@
 {
-  "blobStorageEndpoint": "https://accountName.blob.core.windows.net"
+  "blobStorageEndpoint": "https://accountName.blob.core.windows.net/container-name"
   "messageQueue": {
     "type": "kafka"
     "bootstrapServers": "localhost:9092"

--- a/config/loader/azure/databricks.config.reference.hocon
+++ b/config/loader/azure/databricks.config.reference.hocon
@@ -1,7 +1,11 @@
 {
 
   # Azure Blob Storage endpoint, should contain container with transformer's output
-  "blobStorageEndpoint": "https://accountName.blob.core.windows.net"
+  "blobStorageEndpoint": "https://accountName.blob.core.windows.net/container-name"
+
+  # Name of the Azure Key Vault where application secrets are stored.
+  # Required if secret store is used in storage.password field.
+  "azureVaultName": "azure-vault"
 
   # Kafka topic used by Transformer and Loader to communicate
   "messageQueue": {

--- a/config/loader/azure/databricks.config.reference.hocon
+++ b/config/loader/azure/databricks.config.reference.hocon
@@ -14,9 +14,13 @@
   "storage" : {
     # Hostname of Databricks cluster
     "host": "abc.cloud.databricks.com",
-    # DB password 
-    # TODO handle secret store params instead of plaintext
-    "password": "secret" 
+    # DB password
+    "password": {
+      # A password can be placed in Azure Key Vault or be a plain text
+      "secretStore": {
+        "parameterName": "snowplow.databricks.password"
+      }
+    },
     # Optional. Override the Databricks default catalog, e.g. with a Unity catalog name.
     "catalog": "hive_metastore",
     # DB schema

--- a/config/loader/azure/snowflake.config.minimal.hocon
+++ b/config/loader/azure/snowflake.config.minimal.hocon
@@ -1,5 +1,5 @@
 {
-  "blobStorageEndpoint": "https://accountName.blob.core.windows.net"
+  "blobStorageEndpoint": "https://accountName.blob.core.windows.net/container-name"
   "messageQueue": {
     "type": "kafka"
     "bootstrapServers": "localhost:9092"

--- a/config/loader/azure/snowflake.config.reference.hocon
+++ b/config/loader/azure/snowflake.config.reference.hocon
@@ -1,7 +1,11 @@
 {
 
   # Azure Blob Storage endpoint, should contain container with transformer's output
-  "blobStorageEndpoint": "https://accountName.blob.core.windows.net"
+  "blobStorageEndpoint": "https://accountName.blob.core.windows.net/container-name"
+
+  # Name of the Azure Key Vault where application secrets are stored.
+  # Required if secret store is used in storage.password field.
+  "azureVaultName": "azure-vault"
   
   # Kafka topic used by Transformer and Loader to communicate
   "messageQueue": {

--- a/config/loader/azure/snowflake.config.reference.hocon
+++ b/config/loader/azure/snowflake.config.reference.hocon
@@ -20,8 +20,12 @@
     # DB user with permissions to load data
     "username": "admin",
     # DB password
-    # TODO handle secret store params instead of plaintext
-    "password": "secret" 
+    "password": {
+      # A password can be placed in Azure Key Vault or be a plain text
+      "secretStore": {
+        "parameterName": "snowplow.snowflake.password"
+      }
+    },
     # Snowflake account
     "account": "acme",
     # A warehouse to use for loading

--- a/modules/azure/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureKeyVault.scala
+++ b/modules/azure/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureKeyVault.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and
+ * limitations there under.
+ */
+package com.snowplowanalytics.snowplow.rdbloader.azure
+
+import cats.effect.{Resource, Sync}
+
+import com.azure.identity.DefaultAzureCredentialBuilder
+import com.azure.security.keyvault.secrets.SecretClientBuilder
+
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.SecretStore
+
+object AzureKeyVault {
+
+  def create[F[_]: Sync](keyVaultName: Option[String]): Resource[F, SecretStore[F]] =
+    keyVaultName match {
+      case None =>
+        Resource.pure(new SecretStore[F] {
+          override def getValue(key: String): F[String] =
+            Sync[F].raiseError(new IllegalStateException("Azure vault name isn't given"))
+        })
+      case Some(vaultName) =>
+        for {
+          client <- Resource.eval(Sync[F].delay {
+                      new SecretClientBuilder()
+                        .vaultUrl("https://" + vaultName + ".vault.azure.net")
+                        .credential(new DefaultAzureCredentialBuilder().build())
+                        .buildClient()
+                    })
+          secretStore <- Resource.pure(new SecretStore[F] {
+                           override def getValue(key: String): F[String] =
+                             Sync[F].delay(client.getSecret(key).getValue)
+                         })
+        } yield secretStore
+    }
+
+}

--- a/modules/azure/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureBlobStorageSpec.scala
+++ b/modules/azure/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureBlobStorageSpec.scala
@@ -76,7 +76,8 @@ class AzureBlobStorageSpec extends Specification {
 
   "createStorageUrlFrom" should {
     "return expected URL" in {
-      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
+      AzureBlobStorage
+        .createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
         .use { blobStorage =>
           IO.delay {
             blobStorage.createStorageUrlFrom(s"$testContainerPath/path1/path2/path3/path4")
@@ -86,7 +87,8 @@ class AzureBlobStorageSpec extends Specification {
         Valid(Url("https", Authority.unsafe("test-container"), Path.plain("path1/path2/path3/path4")))
       )
 
-      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath"))
+      AzureBlobStorage
+        .createDefault[IO](URI.create(s"$testContainerPath"))
         .use { blobStorage =>
           IO.delay {
             blobStorage.createStorageUrlFrom(s"$testContainerPath/path1/path2/path3/path4")
@@ -100,7 +102,8 @@ class AzureBlobStorageSpec extends Specification {
 
   "createBlobObject" should {
     "create blob object from given url correctly" in {
-      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
+      AzureBlobStorage
+        .createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
         .use { blobStorage =>
           IO.delay {
             blobStorage.createBlobObject(
@@ -116,10 +119,11 @@ class AzureBlobStorageSpec extends Specification {
           }
         }
         .unsafeRunSync() must beEqualTo(
-          BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
-        )
+        BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
+      )
 
-      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath"))
+      AzureBlobStorage
+        .createDefault[IO](URI.create(s"$testContainerPath"))
         .use { blobStorage =>
           IO.delay {
             blobStorage.createBlobObject(
@@ -135,8 +139,8 @@ class AzureBlobStorageSpec extends Specification {
           }
         }
         .unsafeRunSync() must beEqualTo(
-          BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
-        )
+        BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
+      )
     }
   }
 

--- a/modules/azure/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureBlobStorageSpec.scala
+++ b/modules/azure/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/azure/AzureBlobStorageSpec.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.rdbloader.azure
+
+import java.net.URI
+
+import cats.data.Validated.Valid
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import blobstore.azure.AzureBlob
+import blobstore.url.{Authority, Path, Url}
+
+import com.snowplowanalytics.snowplow.rdbloader.azure.AzureBlobStorage.PathParts
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage
+import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage.Key
+
+import org.specs2.mutable.Specification
+
+class AzureBlobStorageSpec extends Specification {
+  import AzureBlobStorageSpec._
+
+  "PathParts" should {
+    "parse root path" in {
+      PathParts.parse(testContainerPath) must beEqualTo(
+        PathParts(
+          containerName = "test-container",
+          storageAccountName = "accountName",
+          scheme = "https",
+          endpointSuffix = "core.windows.net",
+          relative = ""
+        )
+      )
+    }
+
+    "parse non-root path" in {
+      PathParts.parse(s"$testContainerPath/path1/path2/") must beEqualTo(
+        PathParts(
+          containerName = "test-container",
+          storageAccountName = "accountName",
+          scheme = "https",
+          endpointSuffix = "core.windows.net",
+          relative = "path1/path2/"
+        )
+      )
+    }
+
+    "extract relative path" in {
+      PathParts.parse(testContainerPath).extractRelative(s"$testContainerPath/path1/path2") must beEqualTo(
+        "path1/path2"
+      )
+    }
+
+    "extract root" in {
+      PathParts.parse(s"$testContainerPath/path1/path2").root must beEqualTo(
+        "https://accountName.blob.core.windows.net/"
+      )
+    }
+
+    "convert to parquet path correctly" in {
+      PathParts.parse(s"$testContainerPath/path1/path2").toParquetPath must beEqualTo(
+        "abfss://test-container@accountName.dfs.core.windows.net/path1/path2/"
+      )
+    }
+  }
+
+  "createStorageUrlFrom" should {
+    "return expected URL" in {
+      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
+        .use { blobStorage =>
+          IO.delay {
+            blobStorage.createStorageUrlFrom(s"$testContainerPath/path1/path2/path3/path4")
+          }
+        }
+        .unsafeRunSync() must beEqualTo(
+        Valid(Url("https", Authority.unsafe("test-container"), Path.plain("path1/path2/path3/path4")))
+      )
+
+      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath"))
+        .use { blobStorage =>
+          IO.delay {
+            blobStorage.createStorageUrlFrom(s"$testContainerPath/path1/path2/path3/path4")
+          }
+        }
+        .unsafeRunSync() must beEqualTo(
+        Valid(Url("https", Authority.unsafe("test-container"), Path.plain("path1/path2/path3/path4")))
+      )
+    }
+  }
+
+  "createBlobObject" should {
+    "create blob object from given url correctly" in {
+      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath/path1/path2"))
+        .use { blobStorage =>
+          IO.delay {
+            blobStorage.createBlobObject(
+              Url(
+                "https",
+                Authority.unsafe("test-container"),
+                Path.of(
+                  "path1/path2/path3/path4",
+                  AzureBlob("test-container", "test-blob", None, Map.empty)
+                )
+              )
+            )
+          }
+        }
+        .unsafeRunSync() must beEqualTo(
+          BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
+        )
+
+      AzureBlobStorage.createDefault[IO](URI.create(s"$testContainerPath"))
+        .use { blobStorage =>
+          IO.delay {
+            blobStorage.createBlobObject(
+              Url(
+                "https",
+                Authority.unsafe("test-container"),
+                Path.of(
+                  "path1/path2/path3/path4",
+                  AzureBlob("test-container", "test-blob", None, Map.empty)
+                )
+              )
+            )
+          }
+        }
+        .unsafeRunSync() must beEqualTo(
+          BlobStorage.BlobObject(Key.coerce(s"$testContainerPath/path1/path2/path3/path4"), 0L)
+        )
+    }
+  }
+
+}
+
+object AzureBlobStorageSpec {
+
+  val testContainerPath = "https://accountName.blob.core.windows.net/test-container"
+}

--- a/modules/databricks-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/databricks/ConfigSpec.scala
+++ b/modules/databricks-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/databricks/ConfigSpec.scala
@@ -14,6 +14,8 @@ package com.snowplowanalytics.snowplow.loader.databricks
 
 import scala.concurrent.duration._
 
+import java.net.URI
+
 import cats.effect.IO
 
 import com.snowplowanalytics.snowplow.rdbloader.common.config.Region
@@ -63,6 +65,34 @@ class ConfigSpec extends Specification {
       val expected = Config(
         ConfigSpec.exampleStorage,
         ConfigSpec.exampleGCPCloud,
+        None,
+        monitoring,
+        exampleRetryQueue,
+        exampleSchedules,
+        exampleTimeouts,
+        exampleRetries,
+        exampleReadyCheck,
+        exampleInitRetries,
+        exampleFeatureFlags,
+        exampleTelemetry
+      )
+      result must beRight(expected)
+    }
+
+    "be able to parse extended Azure Databricks Loader config" in {
+      val result = getConfigFromResource("/loader/azure/databricks.config.reference.hocon", Config.parseAppConfig[IO])
+      val monitoring = exampleMonitoring.copy(
+        snowplow = exampleMonitoring.snowplow.map(_.copy(appId = "databricks-loader")),
+        folders = exampleMonitoring.folders.map(
+          _.copy(
+            staging = BlobStorage.Folder.coerce("https://accountName.blob.core.windows.net/staging/"),
+            transformerOutput = BlobStorage.Folder.coerce("https://accountName.blob.core.windows.net/transformed/")
+          )
+        )
+      )
+      val expected = Config(
+        ConfigSpec.exampleStorage,
+        ConfigSpec.exampleAzureCloud,
         None,
         monitoring,
         exampleRetryQueue,
@@ -129,6 +159,32 @@ class ConfigSpec extends Specification {
       )
       result must beRight(expected)
     }
+
+    "be able to parse minimal Azure Snowflake Loader config" in {
+      val result = getConfigFromResource("/loader/azure/databricks.config.minimal.hocon", testParseConfig)
+      val storage = ConfigSpec.exampleStorage.copy(
+        catalog = None,
+        password = StorageTarget.PasswordConfig.PlainText("Supersecret1")
+      )
+      val retries = exampleRetries.copy(cumulativeBound = Some(20.minutes))
+      val readyCheck = exampleReadyCheck.copy(strategy = Config.Strategy.Constant, backoff = 15.seconds)
+      val initRetries = exampleInitRetries.copy(attempts = None, cumulativeBound = Some(10.minutes))
+      val expected = Config(
+        storage,
+        ConfigSpec.exampleAzureCloud.copy(azureVaultName = None),
+        None,
+        defaultMonitoring,
+        None,
+        defaultSchedules,
+        exampleTimeouts,
+        retries,
+        readyCheck,
+        initRetries,
+        exampleFeatureFlags,
+        defaultTelemetry
+      )
+      result must beRight(expected)
+    }
   }
 
 }
@@ -155,5 +211,18 @@ object ConfigSpec {
       parallelPullCount = 1,
       bufferSize = 10
     )
+  )
+  val exampleAzureCloud = Config.Cloud.Azure(
+    blobStorageEndpoint = URI.create("https://accountName.blob.core.windows.net/container-name"),
+    Config.Cloud.Azure.Kafka(
+      topicName = "loaderTopic",
+      bootstrapServers = "localhost:9092",
+      consumerConf = List(
+        "enable.auto.commit" -> "false",
+        "auto.offset.reset" -> "latest",
+        "group.id" -> "loader"
+      ).toMap
+    ),
+    azureVaultName = Some("azure-vault")
   )
 }

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
@@ -25,7 +25,7 @@ import com.snowplowanalytics.snowplow.rdbloader.common.Sentry
 import com.snowplowanalytics.snowplow.rdbloader.common.telemetry.Telemetry
 import com.snowplowanalytics.snowplow.rdbloader.common.cloud.{BlobStorage, Queue, SecretStore}
 import com.snowplowanalytics.snowplow.rdbloader.aws.{EC2ParameterStore, S3, SQS}
-import com.snowplowanalytics.snowplow.rdbloader.azure.{AzureBlobStorage, KafkaConsumer}
+import com.snowplowanalytics.snowplow.rdbloader.azure.{AzureBlobStorage, AzureKeyVault, KafkaConsumer}
 import com.snowplowanalytics.snowplow.rdbloader.gcp.{GCS, Pubsub, SecretManager}
 import com.snowplowanalytics.snowplow.rdbloader.cloud.JsonPathDiscovery
 import com.snowplowanalytics.snowplow.rdbloader.cloud.authservice.{AWSAuthService, AzureAuthService, LoadAuthService}
@@ -195,7 +195,7 @@ object Environment {
                              consumerConf = c.messageQueue.consumerConf,
                              postProcess = Some(postProcess)
                            )
-          secretStore = SecretStore.noop[F] // TODO implement secret store for Azure
+          secretStore <- AzureKeyVault.create(c.azureVaultName)
         } yield CloudServices(blobStorage, queueConsumer, loadAuthService, jsonPathDiscovery, secretStore)
     }
 

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Environment.scala
@@ -188,10 +188,12 @@ object Environment {
               .create[F](c.blobStorageEndpoint.toString, config.storage.eventsLoadAuthMethod, config.storage.foldersLoadAuthMethod)
           jsonPathDiscovery = JsonPathDiscovery.noop[F]
           implicit0(blobStorage: BlobStorage[F]) <- AzureBlobStorage.createDefault[F](c.blobStorageEndpoint)
+          postProcess = Queue.Consumer.postProcess[F]
           queueConsumer <- KafkaConsumer.consumer[F](
                              bootstrapServers = c.messageQueue.bootstrapServers,
                              topicName = c.messageQueue.topicName,
-                             consumerConf = c.messageQueue.consumerConf
+                             consumerConf = c.messageQueue.consumerConf,
+                             postProcess = Some(postProcess)
                            )
           secretStore = SecretStore.noop[F] // TODO implement secret store for Azure
         } yield CloudServices(blobStorage, queueConsumer, loadAuthService, jsonPathDiscovery, secretStore)

--- a/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/ConfigSpec.scala
+++ b/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/ConfigSpec.scala
@@ -111,7 +111,8 @@ class ConfigSpec extends Specification {
       )
       val azureConfig = Config.Cloud.Azure(
         URI.create("https://test.blob.core.windows.net/test-container/"),
-        Config.Cloud.Azure.Kafka("test-topic", "127.0.0.1:8080", Map.empty)
+        Config.Cloud.Azure.Kafka("test-topic", "127.0.0.1:8080", Map.empty),
+        None
       )
       val config = exampleConfig
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,8 @@ object Dependencies {
     val fs2Kafka         = "3.0.0"
     val secretManager    = "2.7.0"
     val gcpStorage       = "2.16.0"
+    val azureIdentity    = "1.9.0"
+    val azureKeyVault    = "4.6.2"
     val doobie           = "1.0.0-RC2"
     val monocle          = "2.0.3"
     val catsRetry        = "3.1.0"
@@ -107,7 +109,8 @@ object Dependencies {
   val fs2BlobstoreS3    = "com.github.fs2-blobstore"   %% "s3"                                % V.fs2Blobstore
   val fs2BlobstoreGCS   = "com.github.fs2-blobstore"   %% "gcs"                               % V.fs2Blobstore
   val fs2BlobstoreAzure = "com.github.fs2-blobstore"   %% "azure"                             % V.fs2Blobstore
-  val azureIdentity     = "com.azure"                  % "azure-identity"                     % "1.9.0"
+  val azureIdentity     = "com.azure"                  % "azure-identity"                     % V.azureIdentity
+  val azureKeyVault     = "com.azure"                  % "azure-security-keyvault-secrets"    % V.azureKeyVault
   val fs2Cron           = "eu.timepit"                 %% "fs2-cron-cron4s"                   % V.fs2Cron
   val fs2PubSub         = "com.permutive"              %% "fs2-google-pubsub-grpc"            % V.fs2PubSub
   val secretManager     = "com.google.cloud"           % "google-cloud-secretmanager"         % V.secretManager
@@ -215,6 +218,7 @@ object Dependencies {
   val azureDependencies = Seq(
     fs2BlobstoreAzure,
     azureIdentity,
+    azureKeyVault,
     fs2Kafka,
     hadoopCommon,
     hadoopAzure


### PR DESCRIPTION
This PR integrates Azure Key Vault to Loaders. It makes possible to fetch database passwords from Azure Key Vault.

Also, postProcess step is added to Loader's Kafka consumer. This step is used to ack messages.