### PR TITLE
Loader: Add monitoring for recovery tables

### DIFF
--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/Loader.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/Loader.scala
@@ -211,11 +211,11 @@ object Loader {
           Load.load[F, C, I](setStageC, incrementAttemptsC, discovery, initQueryResult, target, config.featureFlags.disableMigration)
         attempts <- control.getAndResetAttempts
         _ <- result match {
-               case Load.LoadSuccess(ingested) =>
+               case Load.LoadSuccess(ingested, recoveryTableNames) =>
                  val now = Logging[F].warning("No ingestion timestamp available") *> Clock[F].realTimeInstant
                  for {
                    loaded <- ingested.map(Monad[F].pure).getOrElse(now)
-                   _ <- Load.congratulate[F](attempts, start, loaded, discovery.origin)
+                   _ <- Load.congratulate[F](attempts, start, loaded, discovery.origin, recoveryTableNames)
                    _ <- control.incrementLoaded
                  } yield ()
                case fal: Load.FolderAlreadyLoaded =>

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Migration.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Migration.scala
@@ -253,7 +253,7 @@ object Migration {
           val inAction = Logging[F].info(s"Creating ${b.getName} table for ${target.getInfo.toSchemaUri}") *>
             in.traverse_(item => DAO[F].executeUpdate(item.statement, DAO.Purpose.NonLoading)) *>
             DAO[F].executeUpdate(b.getCommentOn, DAO.Purpose.NonLoading) *>
-            Logging[F].info("Table created")
+            Logging[F].info(s"Table ${b.getName} created")
           migration.addInTransaction(inAction)
 
         case (migration, b @ Block(Nil, in, _)) =>

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Migration.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Migration.scala
@@ -72,7 +72,13 @@ object Migration {
 
     def isCreation: Boolean =
       inTransaction match {
-        case List(Item.CreateTable(_)) => true
+        case List(Item.CreateTable(_, _)) => true
+        case _ => false
+      }
+
+    def isRecovery: Boolean =
+      inTransaction match {
+        case List(Item.CreateTable(_, ir)) => ir
         case _ => false
       }
 
@@ -138,7 +144,7 @@ object Migration {
     }
 
     /** `CREATE TABLE`. Always just one per [[Block]]. Must be in-transaction */
-    final case class CreateTable(createTable: Fragment) extends Item {
+    final case class CreateTable(createTable: Fragment, isRecovery: Boolean) extends Item {
       val statement: Statement = Statement.CreateTable(createTable)
     }
 

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
@@ -72,7 +72,8 @@ object Statement {
     compression: Compression,
     loadAuthMethod: LoadAuthMethod,
     shredModel: ShredModel,
-    tableName: String
+    tableName: String,
+    isRecovered: Boolean
   ) extends Statement
       with Loading {
     def table: String = tableName

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/db/Statement.scala
@@ -75,7 +75,7 @@ object Statement {
     tableName: String
   ) extends Statement
       with Loading {
-    def table: String = shreddedType.info.getName
+    def table: String = tableName
     def path: String = shreddedType.getLoadPath
     def title = s"COPY $table FROM $path"
   }

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Monitoring.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/dsl/Monitoring.scala
@@ -59,7 +59,7 @@ object Monitoring {
 
   def apply[F[_]](implicit ev: Monitoring[F]): Monitoring[F] = ev
 
-  val LoadSucceededSchema = SchemaKey("com.snowplowanalytics.monitoring.batch", "load_succeeded", "jsonschema", SchemaVer.Full(3, 0, 0))
+  val LoadSucceededSchema = SchemaKey("com.snowplowanalytics.monitoring.batch", "load_succeeded", "jsonschema", SchemaVer.Full(3, 0, 1))
   val AlertSchema = SchemaKey("com.snowplowanalytics.monitoring.batch", "alert", "jsonschema", SchemaVer.Full(1, 0, 0))
 
   val Application: String =
@@ -106,6 +106,7 @@ object Monitoring {
     attempt: Int,
     loadingStarted: Instant,
     loadingCompleted: Instant,
+    recoveryTableNames: Option[List[String]],
     tags: Map[String, String]
   )
 
@@ -131,9 +132,12 @@ object Monitoring {
       shredding: ShreddingComplete,
       attempts: Int,
       start: Instant,
-      ingestion: Instant
-    ): SuccessPayload =
-      SuccessPayload(shredding, Application, attempts, start, ingestion, Map.empty)
+      ingestion: Instant,
+      recoveryTableNames: List[String]
+    ): SuccessPayload = {
+      val tableNames = if (recoveryTableNames.isEmpty) None else recoveryTableNames.some
+      SuccessPayload(shredding, Application, attempts, start, ingestion, tableNames, Map.empty)
+    }
   }
 
   def monitoringInterpreter[F[_]: Sync: Logging](

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/loading/Load.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/loading/Load.scala
@@ -19,6 +19,7 @@ import com.snowplowanalytics.snowplow.rdbloader.cloud.authservice.LoadAuthServic
 import com.snowplowanalytics.snowplow.rdbloader.common.LoaderMessage
 import com.snowplowanalytics.snowplow.rdbloader.common.cloud.BlobStorage
 import com.snowplowanalytics.snowplow.rdbloader.db.{Control, Manifest, Migration, Target}
+import com.snowplowanalytics.snowplow.rdbloader.db.Statement.ShreddedCopy
 import com.snowplowanalytics.snowplow.rdbloader.discovery.DataDiscovery
 import com.snowplowanalytics.snowplow.rdbloader.dsl.{DAO, Iglu, Logging, Monitoring, Transaction}
 import com.snowplowanalytics.snowplow.rdbloader.dsl.metrics.Metrics
@@ -56,7 +57,7 @@ object Load {
 
   sealed trait LoadResult
 
-  case class LoadSuccess(ingestionTimestamp: Option[Instant]) extends LoadResult
+  case class LoadSuccess(ingestionTimestamp: Option[Instant], recoveryTableNames: List[String]) extends LoadResult
 
   case class FolderAlreadyLoaded(folder: BlobStorage.Folder) extends LoadResult {
     def toAlert: Alert =
@@ -143,12 +144,14 @@ object Load {
                     Logging[F].info(s"Loading transaction for ${discovery.origin.base} has started") *>
                       setStage(Stage.MigrationIn) *>
                       inTransactionMigrations *>
-                      run[F, I](setLoading, discovery.discovery, initQueryResult, target, disableMigration) *>
-                      setStage(Stage.Committing) *>
-                      Manifest.add[F](discovery.origin.toManifestItem) *>
-                      Manifest
-                        .get[F](discovery.discovery.base)
-                        .map(opt => LoadSuccess(opt.map(_.ingestion)))
+                      run[F, I](setLoading, discovery.discovery, initQueryResult, target, disableMigration).flatMap {
+                        loadedRecoveryTableNames =>
+                          setStage(Stage.Committing) *>
+                            Manifest.add[F](discovery.origin.toManifestItem) *>
+                            Manifest
+                              .get[F](discovery.discovery.base)
+                              .map(opt => LoadSuccess(opt.map(_.ingestion), loadedRecoveryTableNames))
+                      }
                 }
     } yield result
 
@@ -199,34 +202,40 @@ object Load {
     initQueryResult: I,
     target: Target[I],
     disableMigration: List[SchemaCriterion]
-  ): F[Unit] =
+  ): F[List[String]] =
     for {
       _ <- Logging[F].info(s"Loading ${discovery.base}")
       existingEventTableColumns <- if (target.requiresEventsColumns) Control.getColumns[F](EventsTable.MainName) else Nil.pure[F]
-      _ <- target.getLoadStatements(discovery, existingEventTableColumns, initQueryResult, disableMigration).traverse_ { genStatement =>
-             for {
-               loadAuthMethod <- LoadAuthService[F].forLoadingEvents
-               // statement must be generated as late as possible, to have fresh and valid credentials.
-               statement = genStatement(loadAuthMethod)
-               _ <- Logging[F].info(statement.title)
-               _ <- setLoading(statement.table)
-               _ <- DAO[F].executeUpdate(statement, DAO.Purpose.Loading).void
-             } yield ()
-           }
+      loadedRecoveryTableNames <-
+        target.getLoadStatements(discovery, existingEventTableColumns, initQueryResult, disableMigration).toList.traverseFilter {
+          genStatement =>
+            for {
+              loadAuthMethod <- LoadAuthService[F].forLoadingEvents
+              // statement must be generated as late as possible, to have fresh and valid credentials.
+              statement = genStatement(loadAuthMethod)
+              _ <- Logging[F].info(statement.title)
+              _ <- setLoading(statement.table)
+              _ <- DAO[F].executeUpdate(statement, DAO.Purpose.Loading).void
+            } yield statement match {
+              case ShreddedCopy(_, _, _, _, tableName, isRecovered) if isRecovered => tableName.some
+              case _ => None
+            }
+        }
       _ <- Logging[F].info(s"Folder [${discovery.base}] has been loaded (not committed yet)")
-    } yield ()
+    } yield loadedRecoveryTableNames
 
   /** A function to call after successful loading */
   def congratulate[F[_]: Clock: Monad: Logging: Monitoring](
     attempts: Int,
     started: Instant,
     ingestion: Instant,
-    loaded: LoaderMessage.ShreddingComplete
+    loaded: LoaderMessage.ShreddingComplete,
+    recoveryTableNames: List[String]
   ): F[Unit] = {
     val attemptsSuffix = if (attempts > 0) s" after ${attempts} attempts" else ""
     for {
       _ <- Logging[F].info(s"Folder ${loaded.base} loaded successfully$attemptsSuffix")
-      success = Monitoring.SuccessPayload.build(loaded, attempts, started, ingestion)
+      success = Monitoring.SuccessPayload.build(loaded, attempts, started, ingestion, recoveryTableNames)
       _ <- Monitoring[F].success(success)
       metrics <- Metrics.getCompletedMetrics[F](loaded)
       _ <- loaded.timestamps.max.map(t => Monitoring[F].periodicMetrics.setMaxTstampOfLoadedData(t)).sequence.void

--- a/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/loading/LoadSpec.scala
+++ b/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/loading/LoadSpec.scala
@@ -86,7 +86,7 @@ class LoadSpec extends Specification {
             ()
           )
         ),
-        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName)),
+        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName, false)),
         LogEntry.Sql(Statement.ManifestAdd(LoadSpec.dataDiscoveryWithOrigin.origin.toManifestItem)),
         LogEntry.Sql(Statement.ManifestGet("s3://shredded/base/".dir)),
         PureTransaction.CommitMessage
@@ -212,7 +212,7 @@ class LoadSpec extends Specification {
             ()
           )
         ),
-        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName)),
+        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName, false)),
         PureTransaction.RollbackMessage,
         LogEntry.Message("TICK REALTIME"),
         LogEntry.Message("SLEEP 30000000000 nanoseconds"),
@@ -229,7 +229,7 @@ class LoadSpec extends Specification {
             ()
           )
         ),
-        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName)),
+        LogEntry.Sql(Statement.ShreddedCopy(info, Compression.Gzip, LoadAuthMethod.NoCreds, model, model.tableName, false)),
         LogEntry.Sql(Statement.ManifestAdd(LoadSpec.dataDiscoveryWithOrigin.origin.toManifestItem)),
         LogEntry.Sql(Statement.ManifestGet("s3://shredded/base/".dir)),
         PureTransaction.CommitMessage

--- a/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/test/PureDAO.scala
+++ b/modules/loader/src/test/scala/com/snowplowanalytics/snowplow/rdbloader/test/PureDAO.scala
@@ -100,11 +100,12 @@ object PureDAO {
           ),
         discovery.shreddedTypes.map { shredded =>
           val mergeResult = discovery.shredModels(shredded.info.getSchemaKey)
+          val isRecovery = mergeResult.recoveryModels.isDefinedAt(shredded.info.getSchemaKey)
           val shredModel =
             mergeResult.recoveryModels.getOrElse(shredded.info.getSchemaKey, mergeResult.goodModel)
           val isMigrationDisabled = disableMigration.contains(shredded.info.toCriterion)
           val tableName = if (isMigrationDisabled) mergeResult.goodModel.tableName else shredModel.tableName
-          loadAuthMethod => Statement.ShreddedCopy(shredded, Compression.Gzip, loadAuthMethod, shredModel, tableName)
+          loadAuthMethod => Statement.ShreddedCopy(shredded, Compression.Gzip, loadAuthMethod, shredModel, tableName, isRecovery)
         }
       )
 
@@ -126,8 +127,12 @@ object PureDAO {
       throw new Throwable("Not implemented in test suite")
 
     def createTable(shredModel: ShredModel): Migration.Block = {
+      val isRecovery = shredModel match {
+        case ShredModel.GoodModel(_, _, _) => false
+        case ShredModel.RecoveryModel(_, _, _) => true
+      }
       val entity = Migration.Entity.Table("public", shredModel.schemaKey, shredModel.tableName)
-      Block(Nil, List(Item.CreateTable(Fragment.const0(shredModel.toTableSql("public")))), entity)
+      Block(Nil, List(Item.CreateTable(Fragment.const0(shredModel.toTableSql("public")), isRecovery)), entity)
     }
 
     def requiresEventsColumns: Boolean = false

--- a/modules/redshift-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/redshift/db/MigrationSpec.scala
+++ b/modules/redshift-loader/src/test/scala/com/snowplowanalytics/snowplow/loader/redshift/db/MigrationSpec.scala
@@ -97,7 +97,7 @@ class MigrationSpec extends Specification {
         LogEntry.Message("Creating public.com_acme_some_context_2 table for iglu:com.acme/some_context/jsonschema/2-0-0"),
         LogEntry.Sql(Statement.CreateTable(Fragment.const0(createToDdl))),
         LogEntry.Sql(Statement.CommentOn("public.com_acme_some_context_2", "iglu:com.acme/some_context/jsonschema/2-0-0")),
-        LogEntry.Message("Table created")
+        LogEntry.Message("Table public.com_acme_some_context_2 created")
       )
 
       val (state, value) = Migration.build[Pure, Pure, Unit](input, PureDAO.DummyTarget, Nil).run
@@ -184,7 +184,7 @@ class MigrationSpec extends Specification {
         LogEntry.Message("Creating public.com_acme_some_event_1 table for iglu:com.acme/some_event/jsonschema/1-0-0"),
         LogEntry.Sql(Statement.CreateTable(Fragment.const0(createToDdl))),
         LogEntry.Sql(Statement.CommentOn("public.com_acme_some_event_1", "iglu:com.acme/some_event/jsonschema/1-0-0")),
-        LogEntry.Message("Table created")
+        LogEntry.Message("Table public.com_acme_some_event_1 created")
       )
 
       val (state, value) = Migration.build[Pure, Pure, Unit](input, PureDAO.DummyTarget, Nil).run


### PR DESCRIPTION
- [x] RDB Loader logs the name of the recovery table and the schema key that caused the creation
  - Loader was already logging the name of the table being created along with its' schema key, I only fixed the log statement
- [x] RDB Loader emits webhook payload which contains the name of the recovery table & the schema key that caused the creation