### PR TITLE
Loader should not call the "list" Iglu endpoint for Snowflake/Databricks tables

### DIFF
--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/discovery/DataDiscovery.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/discovery/DataDiscovery.scala
@@ -181,7 +181,10 @@ object DataDiscovery {
                                .leftMap(er => LoaderError.DiscoveryError(IgluError(s"Error inferring columns names $er")))
                          }
                      }
-      models <- getShredModels[F](nonAtomicTypes)
+      models <- message.typesInfo match {
+                  case TypesInfo.Shredded(_)   => getShredModels[F](nonAtomicTypes)
+                  case TypesInfo.WideRow(_, _) => EitherT.rightT[F, LoaderError](Map.empty[SchemaKey, DiscoveredShredModels])
+                }
     } yield DataDiscovery(message.base, types.distinct, message.compression, message.typesInfo, wideColumns, models)
   }
 


### PR DESCRIPTION
When loading to Redshift, the loader needs to call the "list" Iglu api endpoint in order to discover all minor versions of a schema. It uses the list to merge the schemas.

But for Snowflake/Databricks tables the loader does not need to merge schemas, so there is no need to call the "list" endpoint.

In RDB Loader version 6.0.0 we accidentally changed the loader so it calls the "list" endpoint regardless of the table type. This is a problem for Snowflake/Databricks loads because:

- it is inefficient to call a api endpoint when we don't need the result
- some old Iglu repos do not support the list endpoint.