### PR TITLE
Upgrade schema-ddl to 0.25.0-M1

### DIFF
--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/Codecs.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/Codecs.scala
@@ -50,7 +50,7 @@ private[parquet] object Codecs {
       case FieldValue.DateValue(value) =>
         as[Date](value)
       case FieldValue.ArrayValue(values) =>
-        as[List[FieldValue]](values)
+        as[Vector[FieldValue]](values)
       case FieldValue.StructValue(values) =>
         values
           .foldLeft[RowParquetRecord](RowParquetRecord()) { case (acc, NamedValue(name, value)) =>

--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetSchema.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/parquet/ParquetSchema.scala
@@ -70,6 +70,6 @@ private[parquet] object ParquetSchema {
       val listElement = asParquetType(element).withRequired(elementNullability.required)
       SchemaDef.list(listElement)
     case Type.Struct(subFields) =>
-      SchemaDef.group(subFields.map(asParquetField): _*)
+      SchemaDef.group(subFields.map(asParquetField).toVector: _*)
   }
 }

--- a/modules/common/src/test/resources/schemas/com.snowplowanalytics.snowplow/digit_schema/jsonschema/1-0-0
+++ b/modules/common/src/test/resources/schemas/com.snowplowanalytics.snowplow/digit_schema/jsonschema/1-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "digit_schema",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "1field": {"type": "string"}
+  },
+  "required": ["1field"]
+}

--- a/modules/transformer-batch/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/batch/SparkSchema.scala
+++ b/modules/transformer-batch/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/batch/SparkSchema.scala
@@ -14,6 +14,8 @@ import com.snowplowanalytics.iglu.schemaddl.parquet.{Field, Type}
 import com.snowplowanalytics.snowplow.rdbloader.common.transformation.parquet.fields.AllFields
 import org.apache.spark.sql.types._
 
+import scala.collection.JavaConverters._
+
 object SparkSchema {
 
   def build(allFields: AllFields): StructType =
@@ -37,7 +39,7 @@ object SparkSchema {
     case Type.Decimal(precision, scale)     => DecimalType(Type.DecimalPrecision.toInt(precision), scale)
     case Type.Date                          => DateType
     case Type.Timestamp                     => TimestampType
-    case Type.Struct(fields)                => StructType(fields.map(asSparkField))
+    case Type.Struct(fields)                => StructType(fields.map(asSparkField).toVector.asJava)
     case Type.Array(element, elNullability) => ArrayType(fieldType(element), elNullability.nullable)
     case Type.Json                          => StringType // Spark does not support the `Json` parquet logical type.
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,13 +39,13 @@ object Dependencies {
     val monocle       = "2.0.3"
     val catsRetry     = "3.1.0"
     val log4cats      = "2.5.0"
-    val http4s        = "0.23.17"
-    val http4sBlaze   = "0.23.14" // this dep fell out of sync with http4s-core versioning - 0.23.14 is the last 0.X release.
+    val http4s        = "0.23.18"
+    val http4sBlaze   = "0.23.16" // this dep fell out of sync with http4s-core versioning - 0.23.16 is the last 0.X release.
     val scalaTracker  = "2.0.0"
 
     val spark           = "3.3.1"
     val eventsManifest  = "0.4.0"
-    val schemaDdl       = "0.22.1"
+    val schemaDdl       = "0.25.0-M1"
     val jacksonModule   = "2.17.2" // Override incompatible version in spark runtime
     val jacksonDatabind = "2.17.2"
     val jacksonMapper   = "1.9.14-atlassian-6" // Fix CVE


### PR DESCRIPTION
This PR upgrades schema-ddl to 0.25.0-M1, making databricks loader prefix fields with an underscore `_` if they start with a number so that we have a consistent behavior across loaders.