### PR TITLE
Use full type name when checking max schema key

### DIFF
--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/discovery/DataDiscovery.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/discovery/DataDiscovery.scala
@@ -195,7 +195,7 @@ object DataDiscovery {
     nonAtomicTypes
       .traverse { shreddedType =>
         EitherT(Iglu[F].getSchemasWithSameModel(shreddedType.info.getSchemaKey)).map { schemas =>
-          val maxSchemaKey                             = maxSchemaKeyPerTableName(shreddedType.info.getName)
+          val maxSchemaKey                             = maxSchemaKeyPerTableName(shreddedType.info.getNameFull)
           val filtered                                 = schemas.filter(_.self.schemaKey <= shreddedType.info.getSchemaKey).toNel.get
           val maxFiltered                              = schemas.filter(_.self.schemaKey <= maxSchemaKey).toNel.get
           val foldMapRedshiftSchemasResult: ShredModel = foldMapRedshiftSchemas(filtered)(shreddedType.info.getSchemaKey)
@@ -210,7 +210,7 @@ object DataDiscovery {
 
   /** Find the maximum SchemaKey for all table names in a given set of shredded types */
   def getMaxSchemaKeyPerTableName(shreddedTypes: List[ShreddedType]): Map[String, SchemaKey] =
-    shreddedTypes.groupBy(_.info.getName).mapValues(_.maxBy(_.info.version).info.getSchemaKey)
+    shreddedTypes.groupBy(_.info.getNameFull).mapValues(_.maxBy(_.info.version).info.getSchemaKey)
 
   def logAndRaise[F[_]: MonadThrow: Logging](error: LoaderError): F[Option[WithOrigin]] =
     Logging[F].error(error)("A problem occurred in the loading of SQS message") *> MonadThrow[F].raiseError(error)


### PR DESCRIPTION
Scenario:

* Input batch contains data using schema, let’s say `link_click`
* `link_click` schema is used as a context AND as an entity/self describing event
* We have multiple versions of  `link_click` schema

When translated to the content of `shredding_complete` JSON message, it would contain Iines like this:
```
      "types": [
        {
          "schemaKey": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-0",
          "snowplowEntity": "SELF_DESCRIBING_EVENT"
        },
        ....
        {
          "schemaKey": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
          "snowplowEntity": "CONTEXT"
        }
      ]
```

For such scenario it looks like we skip necessary warehouse migration for self describing column. We only execute migration for the context:

```
INFO Migration: Migrating contexts_com_snowplowanalytics_snowplow_link_click_1 AddColumn(Fragment("ALTER TABLE atomic.events ADD COLUMN contexts_com_snowplowanalytics_snowplow_link_click_1 ARRAY"),List()) (pre-transaction)
```
but never for `unstruct_event_com_snowplowanalytics_snowplow_link_click_1`, which results in an error when inserting data to the table:

```
ERROR Error executing transaction. Sleeping for 30 seconds for the first time
net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 1,779
invalid identifier 'UNSTRUCT_EVENT_COM_SNOWPLOWANALYTICS_SNOWPLOW_LINK_CLICK_1'
```

It seems to be caused by this [line](https://github.com/snowplow/snowplow-rdb-loader/blob/fffcbe460d7960714116aa7fe606a5ffbb4fd31d/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/discovery/DataDiscovery.scala#L213) where we group incoming types by the name and find max schema key per group. But name doesn’t contain unstruct/context prefix, so it’s possible to “lose” type when schema is used as both context/unstruct + with older version.

I think the solution here could be using full type name instead of simple short name. Full name takes into account if it’s context/unstruct, still groups types, but with additional prefix.